### PR TITLE
Clone Tree and PR List Improvements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "paol0b"
-version = "4.0"
+version = "4.1"
 
 repositories {
     mavenCentral()
@@ -39,6 +39,22 @@ intellijPlatform {
         }
 
         changeNotes = """
+            <h2>Version 4.1 - Clone Dialog Overhaul</h2>
+
+            <h3>Performance</h3>
+            <ul>
+                <li><b>Per-project repo fetching</b> – Replaced the old loop that called the org-wide repositories endpoint once per project (returning the full org each time) with bounded-parallel project-scoped calls. ~50x less data over the wire for large orgs.</li>
+                <li><b>Incremental tree population</b> – Clone tree fills in as each project's repos arrive instead of waiting for everything; first results visible in &lt;1s on big organizations.</li>
+            </ul>
+
+            <h3>New Features</h3>
+            <ul>
+                <li><b>Project filter</b> – Multi-select popup with search and Select All / Deselect All. Selection is persisted per account so subsequent clones jump straight to the projects you care about.</li>
+                <li><b>Chip-style selection field</b> – Selected projects render as removable chips; overflow falls back to a compact "X of Y projects selected" label. Empty selection is treated as "no filter" and shows everything.</li>
+            </ul>
+
+            <hr>
+
             <h2>Version 4.0 - Work Items, Metrics Dashboard & Status Bar</h2>
 
             <h3>New Features</h3>

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,3 @@ kotlin.stdlib.default.dependency=false
 org.gradle.configuration-cache=false
 # Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching=true
-# Heap for the Gradle daemon (the JVM running the build itself)
-org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
-# Heap for the Kotlin compile daemon (separate JVM that compiles .kt files)
-kotlin.daemon.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,7 @@ kotlin.stdlib.default.dependency=false
 org.gradle.configuration-cache=false
 # Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching=true
+# Heap for the Gradle daemon (the JVM running the build itself)
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g
+# Heap for the Kotlin compile daemon (separate JVM that compiles .kt files)
+kotlin.daemon.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g

--- a/src/main/kotlin/paol0b/azuredevops/checkout/AzureDevOpsCloneApiClient.kt
+++ b/src/main/kotlin/paol0b/azuredevops/checkout/AzureDevOpsCloneApiClient.kt
@@ -5,6 +5,8 @@ import com.google.gson.JsonObject
 import com.intellij.openapi.diagnostic.Logger
 import java.net.HttpURLConnection
 import java.net.URI
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 /**
  * API client for fetching projects and repositories from Azure DevOps
@@ -55,32 +57,31 @@ class AzureDevOpsCloneApiClient(
     }
 
     /**
-     * Fetch all repositories for a specific project
+     * Fetch repositories for a single project using the project-scoped endpoint.
+     * Each response only carries that project's repos, so a caller running N of these in
+     * bounded parallel can fill the UI incrementally without redownloading the entire org.
      */
-    fun getRepositories(projectId: String): List<Repository> {
-        val url = "$serverUrl/_apis/git/repositories?api-version=7.0"
+    fun getRepositoriesForProject(projectIdOrName: String): List<Repository> {
+        val encoded = URLEncoder.encode(projectIdOrName, StandardCharsets.UTF_8).replace("+", "%20")
+        val url = "$serverUrl/$encoded/_apis/git/repositories?api-version=7.0"
         val json = executeGet(url)
-        
+
         val jsonObject = gson.fromJson(json, JsonObject::class.java)
         val repositories = mutableListOf<Repository>()
-        
+
         jsonObject.getAsJsonArray("value")?.forEach { element ->
             val repoObj = element.asJsonObject
-            val repoProjectId = repoObj.getAsJsonObject("project")?.get("id")?.asString
-            
-            // Filter repositories by project
-            if (repoProjectId == projectId) {
-                repositories.add(Repository(
-                    id = repoObj.get("id").asString,
-                    name = repoObj.get("name").asString,
-                    remoteUrl = repoObj.get("remoteUrl").asString,
-                    webUrl = repoObj.get("webUrl").asString,
-                    projectId = repoProjectId
-                ))
-            }
+            val repoProjectId = repoObj.getAsJsonObject("project")?.get("id")?.asString ?: return@forEach
+            repositories.add(Repository(
+                id = repoObj.get("id").asString,
+                name = repoObj.get("name").asString,
+                remoteUrl = repoObj.get("remoteUrl").asString,
+                webUrl = repoObj.get("webUrl").asString,
+                projectId = repoProjectId
+            ))
         }
-        
-        logger.info("Fetched ${repositories.size} repositories for project $projectId")
+
+        logger.info("Fetched ${repositories.size} repositories for project $projectIdOrName")
         return repositories
     }
 

--- a/src/main/kotlin/paol0b/azuredevops/checkout/AzureDevOpsCloneDialog.kt
+++ b/src/main/kotlin/paol0b/azuredevops/checkout/AzureDevOpsCloneDialog.kt
@@ -331,16 +331,22 @@ class AzureDevOpsCloneDialog private constructor(
             return
         }
 
-        val token = AzureDevOpsAccountManager.getInstance().getToken(account.id)
-        if (token == null) {
-            CloneTreeHelper.showEmptyState(rootNode, treeModel, "Authentication failed. Please re-login.")
-            updateProjectFilterField(null)
-            return
+        CloneTreeHelper.showEmptyState(rootNode, treeModel, "Loading account…")
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val token = AzureDevOpsAccountManager.getInstance().getToken(account.id)
+            ApplicationManager.getApplication().invokeLater({
+                if (selectedAccount?.id != account.id) return@invokeLater  // user switched mid-fetch
+                if (token == null) {
+                    CloneTreeHelper.showEmptyState(rootNode, treeModel, "Authentication failed. Please re-login.")
+                    updateProjectFilterField(null)
+                    return@invokeLater
+                }
+                val state = AccountState(account, AzureDevOpsCloneApiClient(account.serverUrl, token))
+                accountStates[account.id] = state
+                updateProjectFilterField(state)
+                loadProjectsThenInitRepos(state)
+            }, ModalityState.any())
         }
-        val state = AccountState(account, AzureDevOpsCloneApiClient(account.serverUrl, token))
-        accountStates[account.id] = state
-        updateProjectFilterField(state)
-        loadProjectsThenInitRepos(state)
     }
 
     private fun loadProjectsThenInitRepos(state: AccountState) {

--- a/src/main/kotlin/paol0b/azuredevops/checkout/AzureDevOpsCloneDialog.kt
+++ b/src/main/kotlin/paol0b/azuredevops/checkout/AzureDevOpsCloneDialog.kt
@@ -2,11 +2,11 @@ package paol0b.azuredevops.checkout
 
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
-import com.intellij.openapi.progress.ProgressIndicator
-import com.intellij.openapi.progress.ProgressManager
-import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.TextBrowseFolderListener
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
@@ -28,24 +28,20 @@ import javax.swing.tree.DefaultTreeModel
 import javax.swing.tree.TreeSelectionModel
 
 /**
- * Data class for preloaded projects and repositories
- */
-data class ProjectsData(
-    val projects: List<AzureDevOpsCloneApiClient.Project>,
-    val repositories: Map<String, List<AzureDevOpsCloneApiClient.Repository>>
-)
-
-/**
- * Enhanced clone dialog for Azure DevOps.
- * Shows account selection, projects/repos tree with icons, and target directory.
- * Supports OAuth and PAT authentication with global credential storage.
+ * Enhanced clone dialog for Azure DevOps (standalone variant).
+ *
+ * Loading strategy mirrors [AzureDevOpsCloneDialogComponent]: per-account, lightweight
+ * project list first, then bounded-parallel per-project repo fetches that fill the tree
+ * incrementally. Selected projects are persisted per account via [ProjectSelectionStore].
  */
 class AzureDevOpsCloneDialog private constructor(
-    private val project: Project?,
-    preloadedData: Map<String, ProjectsData>?
+    private val project: Project?
 ) : DialogWrapper(project, true) {
 
-    private val accountComboBox = JComboBox<AzureDevOpsAccount>()
+    private val logger = Logger.getInstance(AzureDevOpsCloneDialog::class.java)
+
+    private val accountComboBox = ComboBox<AzureDevOpsAccount>()
+
     private val loginButton = JButton("Add Account...").apply {
         icon = AllIcons.General.Add
     }
@@ -53,111 +49,47 @@ class AzureDevOpsCloneDialog private constructor(
         icon = AllIcons.General.Remove
         toolTipText = "Remove selected account"
     }
+    private val projectFilterButton = JButton("Loading…").apply {
+        toolTipText = "Pick which Azure DevOps projects should be loaded"
+        horizontalAlignment = SwingConstants.LEFT
+        margin = JBUI.insets(2, 10)
+        isEnabled = false
+    }
+
     private val tree: Tree
     private val treeModel: DefaultTreeModel
     private val rootNode: DefaultMutableTreeNode
     private val directoryField = TextFieldWithBrowseButton()
-    
+
     private val searchField = com.intellij.ui.components.JBTextField()
     private var selectedRepository: AzureDevOpsRepository? = null
     private var selectedAccount: AzureDevOpsAccount? = null
-    private var isLoadingAccounts = false  // Flag to prevent duplicate loads
+    private var isLoadingAccounts = false
     private val defaultCloneDir = System.getProperty("user.home") + File.separator + "source" + File.separator + "repos"
-    private var baseCloneDir = defaultCloneDir  // Track the base directory without repository name
-    
-    // Preloaded data
-    private var preloadedData: Map<String, ProjectsData>? = null
+    private var baseCloneDir = defaultCloneDir
+
+    private val accountStates = mutableMapOf<String, AccountState>()
 
     companion object {
         /**
-         * Factory method to create dialog with preloaded data.
-         * Preloads all projects and repositories for each account before showing the dialog.
+         * Ensures at least one account exists (prompting the login dialog if not) and then
+         * returns a new instance. The dialog opens immediately; project and repo loading
+         * happens incrementally in the background after [show].
          */
         fun create(project: Project?): AzureDevOpsCloneDialog? {
             val accountManager = AzureDevOpsAccountManager.getInstance()
-            val accounts = accountManager.getAccounts()
-            
-            // If no accounts, show login first
-            if (accounts.isEmpty()) {
+            if (accountManager.getAccounts().isEmpty()) {
                 val loginDialog = AzureDevOpsLoginDialog(project)
-                if (!loginDialog.showAndGet()) {
-                    return null
-                }
-                // Reload accounts after login
-                val updatedAccounts = accountManager.getAccounts()
-                if (updatedAccounts.isEmpty()) {
-                    return null
-                }
+                if (!loginDialog.showAndGet()) return null
+                if (accountManager.getAccounts().isEmpty()) return null
             }
-            
-            // Preload data for all accounts
-            var preloadedData: Map<String, ProjectsData>? = null
-            var error: String? = null
-            
-            ProgressManager.getInstance().run(object : Task.Modal(project, "Loading Azure DevOps Repositories...", true) {
-                override fun run(indicator: ProgressIndicator) {
-                    val dataMap = mutableMapOf<String, ProjectsData>()
-                    val currentAccounts = accountManager.getAccounts()
-                    
-                    if (currentAccounts.isEmpty()) {
-                        return
-                    }
-                    
-                    indicator.isIndeterminate = false
-                    val accountCount = currentAccounts.size
-                    
-                    currentAccounts.forEachIndexed { index, account ->
-                        try {
-                            indicator.text = "Loading repositories for ${account.displayName}..."
-                            indicator.fraction = index.toDouble() / accountCount
-                            
-                            val token = accountManager.getToken(account.id)
-                            if (token != null) {
-                                val apiClient = AzureDevOpsCloneApiClient(account.serverUrl, token)
-                                val projects = apiClient.getProjects()
-                                
-                                val repoMap = mutableMapOf<String, List<AzureDevOpsCloneApiClient.Repository>>()
-                                projects.forEachIndexed { projIndex, proj ->
-                                    indicator.text2 = "Loading ${proj.name}..."
-                                    indicator.fraction = (index.toDouble() + (projIndex.toDouble() / projects.size)) / accountCount
-                                    
-                                    try {
-                                        val repos = apiClient.getRepositories(proj.id)
-                                        repoMap[proj.id] = repos
-                                    } catch (e: Exception) {
-                                        // Log and continue
-                                        repoMap[proj.id] = emptyList()
-                                    }
-                                }
-                                
-                                dataMap[account.id] = ProjectsData(projects, repoMap)
-                            }
-                        } catch (e: Exception) {
-                            error = "Error loading repositories for ${account.displayName}: ${e.message}"
-                        }
-                    }
-                    
-                    indicator.fraction = 1.0
-                    preloadedData = dataMap
-                }
-            })
-            
-            if (error != null) {
-                com.intellij.openapi.ui.Messages.showErrorDialog(
-                    project,
-                    error,
-                    "Error Loading Repositories"
-                )
-            }
-            
-            return AzureDevOpsCloneDialog(project, preloadedData)
+            return AzureDevOpsCloneDialog(project)
         }
     }
 
     init {
-        this.preloadedData = preloadedData
         title = "Clone from Azure DevOps"
-        
+
         rootNode = DefaultMutableTreeNode("Azure DevOps")
         treeModel = DefaultTreeModel(rootNode)
         tree = Tree(treeModel).apply {
@@ -171,40 +103,30 @@ class AzureDevOpsCloneDialog private constructor(
         tree.addTreeSelectionListener {
             val selectedNode = tree.lastSelectedPathComponent as? DefaultMutableTreeNode
             val userObject = selectedNode?.userObject
-            
+
             if (userObject is AzureDevOpsRepository) {
                 selectedRepository = userObject
-                
-                // Auto-fill directory with repository name using base directory
                 val targetDir = File(baseCloneDir, userObject.name).absolutePath
                 directoryField.text = targetDir
             } else {
                 selectedRepository = null
             }
         }
-        
-        // Search field listener
-        searchField.getDocument().addDocumentListener(object : javax.swing.event.DocumentListener {
-            override fun insertUpdate(e: javax.swing.event.DocumentEvent?) = filterTree()
-            override fun removeUpdate(e: javax.swing.event.DocumentEvent?) = filterTree()
-            override fun changedUpdate(e: javax.swing.event.DocumentEvent?) = filterTree()
+
+        searchField.document.addDocumentListener(object : javax.swing.event.DocumentListener {
+            override fun insertUpdate(e: javax.swing.event.DocumentEvent?) = rerenderCurrent()
+            override fun removeUpdate(e: javax.swing.event.DocumentEvent?) = rerenderCurrent()
+            override fun changedUpdate(e: javax.swing.event.DocumentEvent?) = rerenderCurrent()
         })
         searchField.emptyText.text = "Search repositories..."
 
-        loginButton.addActionListener {
-            showLoginDialog()
-        }
-
-        removeButton.addActionListener {
-            removeSelectedAccount()
-        }
+        loginButton.addActionListener { showLoginDialog() }
+        removeButton.addActionListener { removeSelectedAccount() }
+        projectFilterButton.addActionListener { openProjectFilterPopup() }
 
         accountComboBox.addActionListener {
-            // Only load repositories if this is a user-triggered change, not programmatic
             if (!isLoadingAccounts) {
-                selectedAccount = accountComboBox.selectedItem as? AzureDevOpsAccount
-                removeButton.isEnabled = selectedAccount != null
-                loadRepositoriesFromPreloadedData()
+                handleAccountChanged()
             }
         }
 
@@ -212,41 +134,35 @@ class AzureDevOpsCloneDialog private constructor(
         directoryField.addBrowseFolderListener(
             TextBrowseFolderListener(fileChooserDescriptor, project)
         )
-        
-        // Listen for manual changes to directory field to update base directory
+
         directoryField.textField.document.addDocumentListener(object : javax.swing.event.DocumentListener {
             override fun insertUpdate(e: javax.swing.event.DocumentEvent?) = updateBaseCloneDir()
             override fun removeUpdate(e: javax.swing.event.DocumentEvent?) = updateBaseCloneDir()
             override fun changedUpdate(e: javax.swing.event.DocumentEvent?) = updateBaseCloneDir()
-            
+
             private fun updateBaseCloneDir() {
                 val currentPath = directoryField.text.trim()
                 if (currentPath.isNotEmpty()) {
                     val currentFile = File(currentPath)
-                    // If a repository is selected and the path ends with its name, use parent
                     if (selectedRepository != null && currentFile.name == selectedRepository?.name) {
                         baseCloneDir = currentFile.parent ?: defaultCloneDir
                     } else {
-                        // Otherwise, use the current path as base
                         baseCloneDir = currentPath
                     }
                 }
             }
         })
-        
-        directoryField.text = defaultCloneDir
 
-        // Initially disable remove button
+        directoryField.text = defaultCloneDir
         removeButton.isEnabled = false
 
         init()
-        loadAccountsWithPreloadedData()
+        loadAccounts()
     }
 
     override fun createCenterPanel(): JComponent {
         val panel = JPanel(BorderLayout(0, 10))
-        
-        // Header with Azure DevOps branding
+
         val headerPanel = JPanel(BorderLayout()).apply {
             val titleLabel = JBLabel("Clone Repository from Azure DevOps").apply {
                 font = font.deriveFont(Font.BOLD, 14f)
@@ -255,18 +171,17 @@ class AzureDevOpsCloneDialog private constructor(
             add(titleLabel, BorderLayout.WEST)
             border = JBUI.Borders.empty(0, 0, 10, 0)
         }
-        
-        // Account selection panel with improved layout
+
         val accountPanel = JPanel(BorderLayout(10, 0)).apply {
             val labelPanel = JPanel(BorderLayout()).apply {
                 add(JBLabel("Account:").apply {
                     font = font.deriveFont(Font.BOLD)
                 }, BorderLayout.WEST)
             }
-            
+
             val comboPanel = JPanel(BorderLayout(5, 0)).apply {
                 add(accountComboBox, BorderLayout.CENTER)
-                
+
                 val buttonPanel = JPanel().apply {
                     layout = BoxLayout(this, BoxLayout.X_AXIS)
                     add(removeButton)
@@ -275,13 +190,20 @@ class AzureDevOpsCloneDialog private constructor(
                 }
                 add(buttonPanel, BorderLayout.EAST)
             }
-            
+
             add(labelPanel, BorderLayout.WEST)
             add(comboPanel, BorderLayout.CENTER)
             border = JBUI.Borders.empty(5, 0, 10, 0)
         }
 
-        // Tree panel with enhanced styling and search
+        val projectsRow = JPanel(BorderLayout(10, 0)).apply {
+            add(JBLabel("Projects:").apply {
+                font = font.deriveFont(Font.BOLD)
+            }, BorderLayout.WEST)
+            add(projectFilterButton, BorderLayout.CENTER)
+            border = JBUI.Borders.empty(0, 0, 10, 0)
+        }
+
         val treePanel = JPanel(BorderLayout()).apply {
             val topPanel = JPanel(BorderLayout()).apply {
                 val treeLabel = JBLabel("Select a Repository:").apply {
@@ -289,8 +211,7 @@ class AzureDevOpsCloneDialog private constructor(
                     border = JBUI.Borders.empty(0, 0, 5, 0)
                 }
                 add(treeLabel, BorderLayout.NORTH)
-                
-                // Search field
+
                 val searchPanel = JPanel(BorderLayout()).apply {
                     searchField.apply {
                         putClientProperty("JTextField.Search.Icon", AllIcons.Actions.Search)
@@ -303,22 +224,21 @@ class AzureDevOpsCloneDialog private constructor(
                 }
                 add(searchPanel, BorderLayout.SOUTH)
             }
-            
+
             val scrollPane = JBScrollPane(tree).apply {
                 border = JBUI.Borders.customLine(UIUtil.getBoundsColor(), 1)
             }
-            
+
             add(topPanel, BorderLayout.NORTH)
             add(scrollPane, BorderLayout.CENTER)
             preferredSize = Dimension(650, 400)
         }
 
-        // Directory panel with improved layout
         val directoryPanel = FormBuilder.createFormBuilder()
             .addLabeledComponent(
-                JBLabel("Directory:").apply { font = font.deriveFont(Font.BOLD) }, 
-                directoryField, 
-                1, 
+                JBLabel("Directory:").apply { font = font.deriveFont(Font.BOLD) },
+                directoryField,
+                1,
                 false
             )
             .panel.apply {
@@ -326,19 +246,28 @@ class AzureDevOpsCloneDialog private constructor(
             }
 
         panel.add(headerPanel, BorderLayout.NORTH)
-        
+
         val centerPanel = JPanel(BorderLayout()).apply {
-            add(accountPanel, BorderLayout.NORTH)
+            val topStack = JPanel().apply {
+                layout = BoxLayout(this, BoxLayout.Y_AXIS)
+                accountPanel.alignmentX = 0f
+                projectsRow.alignmentX = 0f
+                add(accountPanel)
+                add(projectsRow)
+            }
+            add(topStack, BorderLayout.NORTH)
             add(treePanel, BorderLayout.CENTER)
         }
         panel.add(centerPanel, BorderLayout.CENTER)
         panel.add(directoryPanel, BorderLayout.SOUTH)
 
         panel.border = JBUI.Borders.empty(10)
-        panel.preferredSize = Dimension(750, 600)
+        panel.preferredSize = Dimension(750, 620)
 
         return panel
-    }    override fun doValidate(): ValidationInfo? {
+    }
+
+    override fun doValidate(): ValidationInfo? {
         if (selectedRepository == null) {
             return ValidationInfo("Please select a repository to clone", tree)
         }
@@ -357,147 +286,208 @@ class AzureDevOpsCloneDialog private constructor(
     }
 
     fun getSelectedRepository(): AzureDevOpsRepository? = selectedRepository
-    
+
     fun getSelectedAccount(): AzureDevOpsAccount? = selectedAccount
 
     fun getTargetDirectory(): String = directoryField.text.trim()
 
-    private fun loadAccountsWithPreloadedData() {
+    private fun loadAccounts() {
         val accountManager = AzureDevOpsAccountManager.getInstance()
         val accounts = accountManager.getAccounts()
-        
-        // Prevent ActionListener from triggering during programmatic update
+
         isLoadingAccounts = true
         accountComboBox.removeAllItems()
         accounts.forEach { accountComboBox.addItem(it) }
         isLoadingAccounts = false
 
-        if (accounts.isNotEmpty()) {
-            accountComboBox.selectedIndex = 0
-            selectedAccount = accounts.firstOrNull()
-            removeButton.isEnabled = true
-            loadRepositoriesFromPreloadedData()
+        if (accounts.isEmpty()) {
+            selectedAccount = null
+            removeButton.isEnabled = false
+            updateProjectFilterButton(null)
+            CloneTreeHelper.showEmptyState(rootNode, treeModel, "No accounts configured.")
+            return
+        }
+
+        accountComboBox.selectedIndex = 0
+        removeButton.isEnabled = true
+        handleAccountChanged()
+    }
+
+    private fun handleAccountChanged() {
+        val account = accountComboBox.selectedItem as? AzureDevOpsAccount ?: return
+        selectedAccount = account
+        removeButton.isEnabled = true
+
+        val existing = accountStates[account.id]
+        if (existing != null) {
+            updateProjectFilterButton(existing)
+            renderTree(existing)
+            val toLoad = existing.selectedProjectIds.filter {
+                it !in existing.repos && it !in existing.loadingProjectIds
+            }
+            if (toLoad.isNotEmpty()) loadReposFor(existing, toLoad)
+            return
+        }
+
+        val token = AzureDevOpsAccountManager.getInstance().getToken(account.id)
+        if (token == null) {
+            CloneTreeHelper.showEmptyState(rootNode, treeModel, "Authentication failed. Please re-login.")
+            updateProjectFilterButton(null)
+            return
+        }
+        val state = AccountState(account, AzureDevOpsCloneApiClient(account.serverUrl, token))
+        accountStates[account.id] = state
+        updateProjectFilterButton(state)
+        loadProjectsThenInitRepos(state)
+    }
+
+    private fun loadProjectsThenInitRepos(state: AccountState) {
+        CloneTreeHelper.showEmptyState(rootNode, treeModel, "Loading projects…")
+        ApplicationManager.getApplication().executeOnPooledThread {
+            try {
+                val projects = state.apiClient.getProjects()
+                ApplicationManager.getApplication().invokeLater({
+                    state.projects = projects
+                    state.projectsLoaded = true
+
+                    val knownIds = projects.map { it.id }.toSet()
+                    val initialSelection = if (ProjectSelectionStore.isStored(state.account.id)) {
+                        ProjectSelectionStore.load(state.account.id).intersect(knownIds)
+                    } else {
+                        knownIds
+                    }
+                    state.selectedProjectIds = initialSelection.toMutableSet()
+
+                    if (selectedAccount?.id == state.account.id) {
+                        updateProjectFilterButton(state)
+                        renderTree(state)
+                    }
+
+                    if (state.selectedProjectIds.isNotEmpty()) {
+                        loadReposFor(state, state.selectedProjectIds.toList())
+                    }
+                }, ModalityState.any())
+            } catch (e: Exception) {
+                logger.error("Failed to load projects for ${state.account.displayName}", e)
+                ApplicationManager.getApplication().invokeLater({
+                    if (selectedAccount?.id == state.account.id) {
+                        CloneTreeHelper.showEmptyState(rootNode, treeModel, "Error loading projects: ${e.message}")
+                    }
+                }, ModalityState.any())
+            }
         }
     }
 
-    private fun loadAccounts() {
-        val accountManager = AzureDevOpsAccountManager.getInstance()
-        val accounts = accountManager.getAccounts()
-        
-        isLoadingAccounts = true  // Prevent ActionListener from triggering
-        accountComboBox.removeAllItems()
-        accounts.forEach { accountComboBox.addItem(it) }
-        isLoadingAccounts = false
+    private fun loadReposFor(state: AccountState, projectIds: List<String>) {
+        val toFetch = projectIds.filter { it !in state.repos && it !in state.loadingProjectIds }
+        if (toFetch.isEmpty()) return
 
-        if (accounts.isEmpty()) {
-            showLoginDialog()
-        } else {
-            selectedAccount = accounts.firstOrNull()
-            removeButton.isEnabled = selectedAccount != null
-            loadRepositoriesFromPreloadedData()
+        state.loadingProjectIds.addAll(toFetch)
+        if (selectedAccount?.id == state.account.id) renderTree(state)
+
+        state.loader.load(
+            projectIds = toFetch,
+            onLoaded = { projectId, repos ->
+                ApplicationManager.getApplication().invokeLater({
+                    state.repos[projectId] = repos
+                    state.loadingProjectIds.remove(projectId)
+                    if (selectedAccount?.id == state.account.id) renderTree(state)
+                }, ModalityState.any())
+            },
+            onFailed = { projectId, _ ->
+                ApplicationManager.getApplication().invokeLater({
+                    state.repos[projectId] = emptyList()
+                    state.loadingProjectIds.remove(projectId)
+                    if (selectedAccount?.id == state.account.id) renderTree(state)
+                }, ModalityState.any())
+            },
+            onAllDone = { /* tree is updated per project */ }
+        )
+    }
+
+    private fun renderTree(state: AccountState) {
+        if (!state.projectsLoaded) return
+        CloneTreeHelper.render(
+            rootNode = rootNode,
+            treeModel = treeModel,
+            tree = tree,
+            projects = state.projects,
+            repos = state.repos,
+            selectedProjectIds = state.selectedProjectIds,
+            loadingProjectIds = state.loadingProjectIds,
+            searchText = searchField.text
+        )
+    }
+
+    private fun rerenderCurrent() {
+        currentAccountState()?.let { renderTree(it) }
+    }
+
+    private fun updateProjectFilterButton(state: AccountState?) {
+        if (state == null || !state.projectsLoaded) {
+            projectFilterButton.text = "Loading…"
+            projectFilterButton.isEnabled = false
+            return
         }
+        projectFilterButton.text = ProjectFilterPopup.label(state.selectedProjectIds.size, state.projects.size)
+        projectFilterButton.isEnabled = state.projects.isNotEmpty()
+    }
+
+    private fun openProjectFilterPopup() {
+        val state = currentAccountState() ?: return
+        if (!state.projectsLoaded) return
+
+        ProjectFilterPopup.show(
+            anchor = projectFilterButton,
+            projects = state.projects,
+            initiallySelected = state.selectedProjectIds
+        ) { newSelection ->
+            state.selectedProjectIds = newSelection.toMutableSet()
+            ProjectSelectionStore.save(state.account.id, newSelection)
+            updateProjectFilterButton(state)
+            renderTree(state)
+
+            val toLoad = newSelection.filter { it !in state.repos && it !in state.loadingProjectIds }
+            if (toLoad.isNotEmpty()) loadReposFor(state, toLoad)
+        }
+    }
+
+    private fun currentAccountState(): AccountState? {
+        val id = selectedAccount?.id ?: return null
+        return accountStates[id]
     }
 
     private fun showLoginDialog() {
         val loginDialog = AzureDevOpsLoginDialog(project)
         if (loginDialog.showAndGet()) {
-            // Reload with new account - need to fetch data
-            val accountManager = AzureDevOpsAccountManager.getInstance()
-            val newAccount = accountManager.getAccounts().lastOrNull()
-            if (newAccount != null) {
-                loadNewAccountData(newAccount)
-            }
+            loadAccounts()
         }
-    }
-    
-    private fun loadNewAccountData(account: AzureDevOpsAccount) {
-        ProgressManager.getInstance().run(object : Task.Modal(
-            project,
-            "Loading Repositories for ${account.displayName}...",
-            true
-        ) {
-            override fun run(indicator: ProgressIndicator) {
-                try {
-                    val accountManager = AzureDevOpsAccountManager.getInstance()
-                    val token = accountManager.getToken(account.id)
-                    
-                    if (token != null) {
-                        indicator.text = "Fetching projects..."
-                        indicator.isIndeterminate = false
-                        
-                        val apiClient = AzureDevOpsCloneApiClient(account.serverUrl, token)
-                        val projects = apiClient.getProjects()
-                        
-                        val repoMap = mutableMapOf<String, List<AzureDevOpsCloneApiClient.Repository>>()
-                        projects.forEachIndexed { index, proj ->
-                            indicator.text = "Loading ${proj.name}..."
-                            indicator.fraction = index.toDouble() / projects.size
-                            
-                            try {
-                                val repos = apiClient.getRepositories(proj.id)
-                                repoMap[proj.id] = repos
-                            } catch (e: Exception) {
-                                repoMap[proj.id] = emptyList()
-                            }
-                        }
-                        
-                        indicator.fraction = 1.0
-                        
-                        // Update preloaded data
-                        val mutableData = preloadedData?.toMutableMap() ?: mutableMapOf()
-                        mutableData[account.id] = ProjectsData(projects, repoMap)
-                        preloadedData = mutableData
-                        
-                        ApplicationManager.getApplication().invokeLater {
-                            isLoadingAccounts = true
-                            accountComboBox.removeAllItems()
-                            accountManager.getAccounts().forEach { accountComboBox.addItem(it) }
-                            accountComboBox.selectedItem = account
-                            isLoadingAccounts = false
-                            loadRepositoriesFromPreloadedData()
-                        }
-                    }
-                } catch (e: Exception) {
-                    ApplicationManager.getApplication().invokeLater {
-                        com.intellij.openapi.ui.Messages.showErrorDialog(
-                            project,
-                            "Error loading repositories: ${e.message}",
-                            "Error"
-                        )
-                    }
-                }
-            }
-        })
     }
 
     private fun removeSelectedAccount() {
         val account = accountComboBox.selectedItem as? AzureDevOpsAccount ?: return
-        
+
         val confirmed = com.intellij.openapi.ui.Messages.showYesNoDialog(
             project,
             "Are you sure you want to remove the account for '${account.serverUrl}'?\n\n" +
-            "This will delete the stored credentials for this account.",
+                "This will delete the stored credentials for this account.",
             "Remove Account",
             "Remove",
             "Cancel",
             com.intellij.openapi.ui.Messages.getWarningIcon()
         )
-        
+
         if (confirmed == com.intellij.openapi.ui.Messages.YES) {
             val accountManager = AzureDevOpsAccountManager.getInstance()
             accountManager.removeAccount(account.id)
-            
-            // Remove from preloaded data
-            val mutableData = preloadedData?.toMutableMap() ?: mutableMapOf()
-            mutableData.remove(account.id)
-            preloadedData = mutableData
-            
-            // Clear tree and reload accounts
+            accountStates.remove(account.id)
+            ProjectSelectionStore.clear(account.id)
+
             rootNode.removeAllChildren()
             treeModel.reload()
-            
-            loadAccountsWithPreloadedData()
-            
+
+            loadAccounts()
+
             com.intellij.openapi.ui.Messages.showInfoMessage(
                 project,
                 "Account removed successfully.",
@@ -506,22 +496,19 @@ class AzureDevOpsCloneDialog private constructor(
         }
     }
 
-    private fun loadRepositoriesFromPreloadedData() {
-        val account = accountComboBox.selectedItem as? AzureDevOpsAccount ?: return
-        selectedAccount = account
-
-        val data = preloadedData?.get(account.id)
-        if (data == null) {
-            CloneTreeHelper.showEmptyState(rootNode, treeModel, "No data available for this account.")
-            return
-        }
-
-        CloneTreeHelper.populateTree(rootNode, treeModel, tree, data)
-    }
-
-    private fun filterTree() {
-        val account = accountComboBox.selectedItem as? AzureDevOpsAccount ?: return
-        val data = preloadedData?.get(account.id) ?: return
-        CloneTreeHelper.filterTree(rootNode, treeModel, tree, data, searchField.text)
+    /**
+     * Per-account snapshot of what's been loaded so far. Lives for the lifetime of the
+     * dialog so re-selecting an account keeps its already-fetched repos cached.
+     */
+    private class AccountState(
+        val account: AzureDevOpsAccount,
+        val apiClient: AzureDevOpsCloneApiClient
+    ) {
+        var projects: List<AzureDevOpsCloneApiClient.Project> = emptyList()
+        var projectsLoaded: Boolean = false
+        val repos: MutableMap<String, List<AzureDevOpsCloneApiClient.Repository>> = mutableMapOf()
+        var selectedProjectIds: MutableSet<String> = mutableSetOf()
+        val loadingProjectIds: MutableSet<String> = mutableSetOf()
+        val loader: RepositoryLoader = RepositoryLoader(apiClient)
     }
 }

--- a/src/main/kotlin/paol0b/azuredevops/checkout/AzureDevOpsCloneDialog.kt
+++ b/src/main/kotlin/paol0b/azuredevops/checkout/AzureDevOpsCloneDialog.kt
@@ -49,10 +49,11 @@ class AzureDevOpsCloneDialog private constructor(
         icon = AllIcons.General.Remove
         toolTipText = "Remove selected account"
     }
-    private val projectFilterButton = JButton("Loading…").apply {
+    private val projectFilterField = SelectedProjectsField(
+        onClick = { openProjectFilterPopup() },
+        onRemove = { projectId -> removeProjectFromSelection(projectId) }
+    ).apply {
         toolTipText = "Pick which Azure DevOps projects should be loaded"
-        horizontalAlignment = SwingConstants.LEFT
-        margin = JBUI.insets(2, 10)
         isEnabled = false
     }
 
@@ -122,7 +123,6 @@ class AzureDevOpsCloneDialog private constructor(
 
         loginButton.addActionListener { showLoginDialog() }
         removeButton.addActionListener { removeSelectedAccount() }
-        projectFilterButton.addActionListener { openProjectFilterPopup() }
 
         accountComboBox.addActionListener {
             if (!isLoadingAccounts) {
@@ -200,7 +200,7 @@ class AzureDevOpsCloneDialog private constructor(
             add(JBLabel("Projects:").apply {
                 font = font.deriveFont(Font.BOLD)
             }, BorderLayout.WEST)
-            add(projectFilterButton, BorderLayout.CENTER)
+            add(projectFilterField, BorderLayout.CENTER)
             border = JBUI.Borders.empty(0, 0, 10, 0)
         }
 
@@ -303,7 +303,7 @@ class AzureDevOpsCloneDialog private constructor(
         if (accounts.isEmpty()) {
             selectedAccount = null
             removeButton.isEnabled = false
-            updateProjectFilterButton(null)
+            updateProjectFilterField(null)
             CloneTreeHelper.showEmptyState(rootNode, treeModel, "No accounts configured.")
             return
         }
@@ -320,24 +320,26 @@ class AzureDevOpsCloneDialog private constructor(
 
         val existing = accountStates[account.id]
         if (existing != null) {
-            updateProjectFilterButton(existing)
+            updateProjectFilterField(existing)
             renderTree(existing)
-            val toLoad = existing.selectedProjectIds.filter {
-                it !in existing.repos && it !in existing.loadingProjectIds
+            if (existing.projectsLoaded) {
+                val toLoad = effectiveSelection(existing).filter {
+                    it !in existing.repos && it !in existing.loadingProjectIds
+                }
+                if (toLoad.isNotEmpty()) loadReposFor(existing, toLoad)
             }
-            if (toLoad.isNotEmpty()) loadReposFor(existing, toLoad)
             return
         }
 
         val token = AzureDevOpsAccountManager.getInstance().getToken(account.id)
         if (token == null) {
             CloneTreeHelper.showEmptyState(rootNode, treeModel, "Authentication failed. Please re-login.")
-            updateProjectFilterButton(null)
+            updateProjectFilterField(null)
             return
         }
         val state = AccountState(account, AzureDevOpsCloneApiClient(account.serverUrl, token))
         accountStates[account.id] = state
-        updateProjectFilterButton(state)
+        updateProjectFilterField(state)
         loadProjectsThenInitRepos(state)
     }
 
@@ -359,13 +361,11 @@ class AzureDevOpsCloneDialog private constructor(
                     state.selectedProjectIds = initialSelection.toMutableSet()
 
                     if (selectedAccount?.id == state.account.id) {
-                        updateProjectFilterButton(state)
+                        updateProjectFilterField(state)
                         renderTree(state)
                     }
 
-                    if (state.selectedProjectIds.isNotEmpty()) {
-                        loadReposFor(state, state.selectedProjectIds.toList())
-                    }
+                    loadReposFor(state, effectiveSelection(state).toList())
                 }, ModalityState.any())
             } catch (e: Exception) {
                 logger.error("Failed to load projects for ${state.account.displayName}", e)
@@ -423,14 +423,28 @@ class AzureDevOpsCloneDialog private constructor(
         currentAccountState()?.let { renderTree(it) }
     }
 
-    private fun updateProjectFilterButton(state: AccountState?) {
+    private fun updateProjectFilterField(state: AccountState?) {
         if (state == null || !state.projectsLoaded) {
-            projectFilterButton.text = "Loading…"
-            projectFilterButton.isEnabled = false
+            projectFilterField.setSelection(projectsLoaded = false, totalProjects = 0, selected = emptyList())
+            projectFilterField.isEnabled = false
             return
         }
-        projectFilterButton.text = ProjectFilterPopup.label(state.selectedProjectIds.size, state.projects.size)
-        projectFilterButton.isEnabled = state.projects.isNotEmpty()
+        val selected = state.projects.filter { it.id in state.selectedProjectIds }
+        projectFilterField.setSelection(
+            projectsLoaded = true,
+            totalProjects = state.projects.size,
+            selected = selected
+        )
+        projectFilterField.isEnabled = state.projects.isNotEmpty()
+    }
+
+    private fun removeProjectFromSelection(projectId: String) {
+        val state = currentAccountState() ?: return
+        if (!state.projectsLoaded) return
+        if (!state.selectedProjectIds.remove(projectId)) return
+        ProjectSelectionStore.save(state.account.id, state.selectedProjectIds)
+        updateProjectFilterField(state)
+        renderTree(state)
     }
 
     private fun openProjectFilterPopup() {
@@ -438,19 +452,27 @@ class AzureDevOpsCloneDialog private constructor(
         if (!state.projectsLoaded) return
 
         ProjectFilterPopup.show(
-            anchor = projectFilterButton,
+            anchor = projectFilterField,
             projects = state.projects,
-            initiallySelected = state.selectedProjectIds
+            initiallySelected = effectiveSelection(state)
         ) { newSelection ->
             state.selectedProjectIds = newSelection.toMutableSet()
             ProjectSelectionStore.save(state.account.id, newSelection)
-            updateProjectFilterButton(state)
+            updateProjectFilterField(state)
             renderTree(state)
 
-            val toLoad = newSelection.filter { it !in state.repos && it !in state.loadingProjectIds }
-            if (toLoad.isNotEmpty()) loadReposFor(state, toLoad)
+            val toFetch = effectiveSelection(state).filter {
+                it !in state.repos && it !in state.loadingProjectIds
+            }
+            if (toFetch.isNotEmpty()) loadReposFor(state, toFetch)
         }
     }
+
+    /** Project ids that should currently be visible: the explicit selection, or every
+     *  project when the explicit selection is empty (= "no filter"). */
+    private fun effectiveSelection(state: AccountState): Set<String> =
+        if (state.selectedProjectIds.isEmpty()) state.projects.map { it.id }.toSet()
+        else state.selectedProjectIds.toSet()
 
     private fun currentAccountState(): AccountState? {
         val id = selectedAccount?.id ?: return null

--- a/src/main/kotlin/paol0b/azuredevops/checkout/AzureDevOpsCloneDialogComponent.kt
+++ b/src/main/kotlin/paol0b/azuredevops/checkout/AzureDevOpsCloneDialogComponent.kt
@@ -79,6 +79,10 @@ fun normalizeAzureDevOpsUrl(url: String): String {
 /**
  * Main component for Azure DevOps in the Clone Repository dialog.
  * Matches GitHub/GitLab style: account at top, tree in middle, clone options at bottom.
+ *
+ * Loading strategy: per-account, lightweight project list first, then bounded-parallel
+ * per-project repo fetches that fill the tree incrementally. Selected projects are
+ * persisted per account via [ProjectSelectionStore].
  */
 class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDialogExtensionComponent() {
 
@@ -90,6 +94,13 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
         toolTipText = "Add Account"
         isBorderPainted = false
         isContentAreaFilled = false
+    }
+
+    // Project filter button (multi-select popup)
+    private val projectFilterButton = JButton("Projects: —").apply {
+        toolTipText = "Pick which Azure DevOps projects should be loaded"
+        horizontalAlignment = SwingConstants.LEFT
+        margin = JBUI.insets(2, 10)
     }
 
     // Search and tree
@@ -104,7 +115,7 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
     private val shallowCloneDepthField = JTextField("1", 5)
     private val commitsLabel = JBLabel("commits")
 
-    private var preloadedData: MutableMap<String, ProjectsData> = mutableMapOf()
+    private val accountStates = mutableMapOf<String, AccountState>()
     private var selectedRepository: AzureDevOpsRepository? = null
     private var selectedAccount: AzureDevOpsAccount? = null
     private var isLoadingAccounts = false
@@ -148,20 +159,17 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
 
             if (userObject is AzureDevOpsRepository) {
                 selectedRepository = userObject
-                // Update directory with repo name
                 val repoDir = File(baseCloneDir, userObject.name).absolutePath
                 directoryField.text = repoDir
             } else {
                 selectedRepository = null
             }
-            // Notify dialog of state change to enable/disable Clone button
             notifyDialogStateChanged()
         }
 
-        // Search field listener
         searchField.addDocumentListener(object : DocumentAdapter() {
             override fun textChanged(e: DocumentEvent) {
-                filterTree()
+                currentAccountState()?.let { renderTree(it) }
             }
         })
 
@@ -171,9 +179,12 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
 
         accountComboBox.addActionListener {
             if (!isLoadingAccounts) {
-                selectedAccount = accountComboBox.selectedItem as? AzureDevOpsAccount
-                loadRepositoriesForCurrentAccount()
+                handleAccountChanged()
             }
+        }
+
+        projectFilterButton.addActionListener {
+            openProjectFilterPopup()
         }
 
         // Directory field setup
@@ -183,7 +194,6 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
         )
         directoryField.text = defaultCloneDir
 
-        // Listen for directory changes to trigger validation
         directoryField.textField.document.addDocumentListener(object : DocumentAdapter() {
             override fun textChanged(e: DocumentEvent) {
                 notifyDialogStateChanged()
@@ -202,24 +212,31 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
     private fun createMainPanel(): JPanel {
         val panel = JPanel(BorderLayout())
 
-        // === TOP: Account selection with logo ===
-        val accountPanel = JPanel(BorderLayout(8, 0)).apply {
+        // === TOP: Account selection + project filter ===
+        val topPanel = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
             border = JBUI.Borders.empty(0, 0, 8, 0)
 
-            // Account combo + add button
             val accountRow = JPanel(BorderLayout(4, 0)).apply {
                 add(accountComboBox, BorderLayout.CENTER)
                 add(addAccountButton, BorderLayout.EAST)
+                alignmentX = 0f
             }
-            add(accountRow, BorderLayout.CENTER)
+            add(accountRow)
+
+            val filterRow = JPanel(BorderLayout(4, 0)).apply {
+                border = JBUI.Borders.emptyTop(6)
+                add(JBLabel("Projects:"), BorderLayout.WEST)
+                add(projectFilterButton, BorderLayout.CENTER)
+                alignmentX = 0f
+            }
+            add(filterRow)
         }
 
         // === MIDDLE: Search + Tree ===
         val centerPanel = JPanel(BorderLayout(0, 8)).apply {
-            // Search at top
             add(searchField, BorderLayout.NORTH)
 
-            // Tree in scroll pane
             val scrollPane = JBScrollPane(tree).apply {
                 border = JBUI.Borders.customLine(UIUtil.getBoundsColor(), 1)
             }
@@ -230,14 +247,12 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
         val bottomPanel = JPanel(BorderLayout(0, 8)).apply {
             border = JBUI.Borders.empty(8, 0, 0, 0)
 
-            // Directory row
             val directoryRow = JPanel(BorderLayout(8, 0)).apply {
                 add(JBLabel("Directory:"), BorderLayout.WEST)
                 add(directoryField, BorderLayout.CENTER)
             }
             add(directoryRow, BorderLayout.NORTH)
 
-            // Shallow clone row
             val shallowRow = JPanel(FlowLayout(FlowLayout.LEFT, 4, 0)).apply {
                 add(shallowCloneCheckbox)
                 add(shallowCloneDepthField)
@@ -246,7 +261,7 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
             add(shallowRow, BorderLayout.SOUTH)
         }
 
-        panel.add(accountPanel, BorderLayout.NORTH)
+        panel.add(topPanel, BorderLayout.NORTH)
         panel.add(centerPanel, BorderLayout.CENTER)
         panel.add(bottomPanel, BorderLayout.SOUTH)
 
@@ -294,7 +309,6 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
 
                     handler.addParameters("--progress")
 
-                    // Add shallow clone option if enabled
                     if (isShallowClone) {
                         handler.addParameters("--depth", shallowDepth.toString())
                     }
@@ -318,20 +332,12 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
                     indicator.fraction = 1.0
 
                     if (result.success()) {
-                        // Persist auth token directly in the repo's local git config so that
-                        // all subsequent git operations (pull, push, fetch) are authenticated
-                        // without relying on the OS credential store, and so the token can be
-                        // refreshed automatically when it expires.
                         val gitTokenManager = GitTokenManager.getInstance()
                         gitTokenManager.registerRepo(checkoutDir.absolutePath, account.id)
                         if (token != null) {
                             gitTokenManager.writeAuthHeader(checkoutDir.absolutePath, token)
                         }
 
-                        // Refresh VFS so IntelliJ picks up the new directory, then notify the
-                        // framework listener directly from the background thread — this is the
-                        // same pattern used by GitCheckoutProvider.doClone.  The listener
-                        // implementations internally dispatch close() onto the EDT.
                         VfsUtil.markDirtyAndRefresh(false, true, true, checkoutDir.parentFile)
                         checkoutListener.directoryCheckedOut(checkoutDir, GitVcs.getKey())
                         checkoutListener.checkoutCompleted()
@@ -371,74 +377,157 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
         isLoadingAccounts = false
 
         if (accounts.isEmpty()) {
+            selectedAccount = null
+            updateProjectFilterButton(null)
             CloneTreeHelper.showEmptyState(rootNode, treeModel, "No accounts configured. Click '+' to add an account.")
         } else {
             accountComboBox.selectedIndex = 0
-            selectedAccount = accounts.firstOrNull()
-            loadRepositoriesForCurrentAccount()
-            // Notify dialog to check validation
+            handleAccountChanged()
             notifyDialogStateChanged()
         }
     }
 
-    private fun loadRepositoriesForCurrentAccount() {
+    private fun handleAccountChanged() {
         val account = accountComboBox.selectedItem as? AzureDevOpsAccount ?: return
         selectedAccount = account
 
-        // Check if we have preloaded data
-        val data = preloadedData[account.id]
-        if (data != null) {
-            CloneTreeHelper.populateTree(rootNode, treeModel, tree, data)
-            notifyDialogStateChanged()
+        val existing = accountStates[account.id]
+        if (existing != null) {
+            updateProjectFilterButton(existing)
+            renderTree(existing)
+            // If projects exist but some selected ones have no repos yet, kick off their fetch.
+            if (existing.projectsLoaded) {
+                val toLoad = existing.selectedProjectIds.filter {
+                    it !in existing.repos && it !in existing.loadingProjectIds
+                }
+                if (toLoad.isNotEmpty()) loadReposFor(existing, toLoad)
+            }
             return
         }
 
-        // Show loading state
-        CloneTreeHelper.showEmptyState(rootNode, treeModel, "Loading repositories...")
+        val token = AzureDevOpsAccountManager.getInstance().getToken(account.id)
+        if (token == null) {
+            CloneTreeHelper.showEmptyState(rootNode, treeModel, "Authentication failed. Please re-login.")
+            updateProjectFilterButton(null)
+            return
+        }
+        val state = AccountState(account, AzureDevOpsCloneApiClient(account.serverUrl, token))
+        accountStates[account.id] = state
+        updateProjectFilterButton(state)
+        loadProjectsThenInitRepos(state)
+    }
 
-        // Load in background
+    private fun loadProjectsThenInitRepos(state: AccountState) {
+        CloneTreeHelper.showEmptyState(rootNode, treeModel, "Loading projects…")
         ApplicationManager.getApplication().executeOnPooledThread {
             try {
-                val accountManager = AzureDevOpsAccountManager.getInstance()
-                val token = accountManager.getToken(account.id)
+                val projects = state.apiClient.getProjects()
+                ApplicationManager.getApplication().invokeLater({
+                    state.projects = projects
+                    state.projectsLoaded = true
 
-                if (token != null) {
-                    val apiClient = AzureDevOpsCloneApiClient(account.serverUrl, token)
-                    val projects = apiClient.getProjects()
+                    val knownIds = projects.map { it.id }.toSet()
+                    val initialSelection = if (ProjectSelectionStore.isStored(state.account.id)) {
+                        ProjectSelectionStore.load(state.account.id).intersect(knownIds)
+                    } else {
+                        knownIds
+                    }
+                    state.selectedProjectIds = initialSelection.toMutableSet()
 
-                    val repoMap = mutableMapOf<String, List<AzureDevOpsCloneApiClient.Repository>>()
-                    projects.forEach { proj ->
-                        try {
-                            val repos = apiClient.getRepositories(proj.id)
-                            repoMap[proj.id] = repos
-                        } catch (e: Exception) {
-                            logger.warn("Failed to load repos for project ${proj.name}", e)
-                            repoMap[proj.id] = emptyList()
-                        }
+                    if (selectedAccount?.id == state.account.id) {
+                        updateProjectFilterButton(state)
+                        renderTree(state)
                     }
 
-                    val projectsData = ProjectsData(projects, repoMap)
-                    preloadedData[account.id] = projectsData
-
-                    ApplicationManager.getApplication().invokeLater({
-                        CloneTreeHelper.populateTree(rootNode, treeModel, tree, projectsData)
-                        // Notify dialog after tree is populated
-                        notifyDialogStateChanged()
-                    }, ModalityState.any())
-                } else {
-                    ApplicationManager.getApplication().invokeLater({
-                        CloneTreeHelper.showEmptyState(rootNode, treeModel, "Authentication failed. Please re-login.")
-                        notifyDialogStateChanged()
-                    }, ModalityState.any())
-                }
+                    if (state.selectedProjectIds.isNotEmpty()) {
+                        loadReposFor(state, state.selectedProjectIds.toList())
+                    }
+                }, ModalityState.any())
             } catch (e: Exception) {
-                logger.error("Failed to load repositories", e)
+                logger.error("Failed to load projects for ${state.account.displayName}", e)
                 ApplicationManager.getApplication().invokeLater({
-                    CloneTreeHelper.showEmptyState(rootNode, treeModel, "Error loading repositories: ${e.message}")
-                    notifyDialogStateChanged()
+                    if (selectedAccount?.id == state.account.id) {
+                        CloneTreeHelper.showEmptyState(rootNode, treeModel, "Error loading projects: ${e.message}")
+                    }
                 }, ModalityState.any())
             }
         }
+    }
+
+    private fun loadReposFor(state: AccountState, projectIds: List<String>) {
+        val toFetch = projectIds.filter { it !in state.repos && it !in state.loadingProjectIds }
+        if (toFetch.isEmpty()) return
+
+        state.loadingProjectIds.addAll(toFetch)
+        if (selectedAccount?.id == state.account.id) renderTree(state)
+
+        state.loader.load(
+            projectIds = toFetch,
+            onLoaded = { projectId, repos ->
+                ApplicationManager.getApplication().invokeLater({
+                    state.repos[projectId] = repos
+                    state.loadingProjectIds.remove(projectId)
+                    if (selectedAccount?.id == state.account.id) renderTree(state)
+                }, ModalityState.any())
+            },
+            onFailed = { projectId, _ ->
+                ApplicationManager.getApplication().invokeLater({
+                    state.repos[projectId] = emptyList()
+                    state.loadingProjectIds.remove(projectId)
+                    if (selectedAccount?.id == state.account.id) renderTree(state)
+                }, ModalityState.any())
+            },
+            onAllDone = { /* no-op; the tree is updated incrementally */ }
+        )
+    }
+
+    private fun renderTree(state: AccountState) {
+        if (!state.projectsLoaded) return
+        CloneTreeHelper.render(
+            rootNode = rootNode,
+            treeModel = treeModel,
+            tree = tree,
+            projects = state.projects,
+            repos = state.repos,
+            selectedProjectIds = state.selectedProjectIds,
+            loadingProjectIds = state.loadingProjectIds,
+            searchText = searchField.text
+        )
+        notifyDialogStateChanged()
+    }
+
+    private fun updateProjectFilterButton(state: AccountState?) {
+        if (state == null || !state.projectsLoaded) {
+            projectFilterButton.text = "Loading…"
+            projectFilterButton.isEnabled = false
+            return
+        }
+        projectFilterButton.text = ProjectFilterPopup.label(state.selectedProjectIds.size, state.projects.size)
+        projectFilterButton.isEnabled = state.projects.isNotEmpty()
+    }
+
+    private fun openProjectFilterPopup() {
+        val state = currentAccountState() ?: return
+        if (!state.projectsLoaded) return
+
+        ProjectFilterPopup.show(
+            anchor = projectFilterButton,
+            projects = state.projects,
+            initiallySelected = state.selectedProjectIds
+        ) { newSelection ->
+            state.selectedProjectIds = newSelection.toMutableSet()
+            ProjectSelectionStore.save(state.account.id, newSelection)
+            updateProjectFilterButton(state)
+            renderTree(state)
+
+            val toLoad = newSelection.filter { it !in state.repos && it !in state.loadingProjectIds }
+            if (toLoad.isNotEmpty()) loadReposFor(state, toLoad)
+        }
+    }
+
+    private fun currentAccountState(): AccountState? {
+        val id = selectedAccount?.id ?: return null
+        return accountStates[id]
     }
 
     private fun notifyDialogStateChanged() {
@@ -455,17 +544,26 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
         }
     }
 
-    private fun filterTree() {
-        val account = accountComboBox.selectedItem as? AzureDevOpsAccount ?: return
-        val data = preloadedData[account.id] ?: return
-        CloneTreeHelper.filterTree(rootNode, treeModel, tree, data, searchField.text)
-    }
-
     private fun showLoginDialog() {
         val loginDialog = AzureDevOpsLoginDialog(project)
         if (loginDialog.showAndGet()) {
-            // Reload accounts after login
             loadAccounts()
         }
+    }
+
+    /**
+     * Per-account snapshot of what's been loaded so far. Lives for the lifetime of the
+     * dialog so re-selecting an account keeps its already-fetched repos cached.
+     */
+    private class AccountState(
+        val account: AzureDevOpsAccount,
+        val apiClient: AzureDevOpsCloneApiClient
+    ) {
+        var projects: List<AzureDevOpsCloneApiClient.Project> = emptyList()
+        var projectsLoaded: Boolean = false
+        val repos: MutableMap<String, List<AzureDevOpsCloneApiClient.Repository>> = mutableMapOf()
+        var selectedProjectIds: MutableSet<String> = mutableSetOf()
+        val loadingProjectIds: MutableSet<String> = mutableSetOf()
+        val loader: RepositoryLoader = RepositoryLoader(apiClient)
     }
 }

--- a/src/main/kotlin/paol0b/azuredevops/checkout/AzureDevOpsCloneDialogComponent.kt
+++ b/src/main/kotlin/paol0b/azuredevops/checkout/AzureDevOpsCloneDialogComponent.kt
@@ -96,11 +96,12 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
         isContentAreaFilled = false
     }
 
-    // Project filter button (multi-select popup)
-    private val projectFilterButton = JButton("Projects: —").apply {
+    // Project filter field — chips + click-to-open-popup
+    private val projectFilterField = SelectedProjectsField(
+        onClick = { openProjectFilterPopup() },
+        onRemove = { projectId -> removeProjectFromSelection(projectId) }
+    ).apply {
         toolTipText = "Pick which Azure DevOps projects should be loaded"
-        horizontalAlignment = SwingConstants.LEFT
-        margin = JBUI.insets(2, 10)
     }
 
     // Search and tree
@@ -183,10 +184,6 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
             }
         }
 
-        projectFilterButton.addActionListener {
-            openProjectFilterPopup()
-        }
-
         // Directory field setup
         val fileChooserDescriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor()
         directoryField.addBrowseFolderListener(
@@ -227,7 +224,7 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
             val filterRow = JPanel(BorderLayout(4, 0)).apply {
                 border = JBUI.Borders.emptyTop(6)
                 add(JBLabel("Projects:"), BorderLayout.WEST)
-                add(projectFilterButton, BorderLayout.CENTER)
+                add(projectFilterField, BorderLayout.CENTER)
                 alignmentX = 0f
             }
             add(filterRow)
@@ -378,7 +375,7 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
 
         if (accounts.isEmpty()) {
             selectedAccount = null
-            updateProjectFilterButton(null)
+            updateProjectFilterField(null)
             CloneTreeHelper.showEmptyState(rootNode, treeModel, "No accounts configured. Click '+' to add an account.")
         } else {
             accountComboBox.selectedIndex = 0
@@ -393,11 +390,10 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
 
         val existing = accountStates[account.id]
         if (existing != null) {
-            updateProjectFilterButton(existing)
+            updateProjectFilterField(existing)
             renderTree(existing)
-            // If projects exist but some selected ones have no repos yet, kick off their fetch.
             if (existing.projectsLoaded) {
-                val toLoad = existing.selectedProjectIds.filter {
+                val toLoad = effectiveSelection(existing).filter {
                     it !in existing.repos && it !in existing.loadingProjectIds
                 }
                 if (toLoad.isNotEmpty()) loadReposFor(existing, toLoad)
@@ -408,12 +404,12 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
         val token = AzureDevOpsAccountManager.getInstance().getToken(account.id)
         if (token == null) {
             CloneTreeHelper.showEmptyState(rootNode, treeModel, "Authentication failed. Please re-login.")
-            updateProjectFilterButton(null)
+            updateProjectFilterField(null)
             return
         }
         val state = AccountState(account, AzureDevOpsCloneApiClient(account.serverUrl, token))
         accountStates[account.id] = state
-        updateProjectFilterButton(state)
+        updateProjectFilterField(state)
         loadProjectsThenInitRepos(state)
     }
 
@@ -435,13 +431,11 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
                     state.selectedProjectIds = initialSelection.toMutableSet()
 
                     if (selectedAccount?.id == state.account.id) {
-                        updateProjectFilterButton(state)
+                        updateProjectFilterField(state)
                         renderTree(state)
                     }
 
-                    if (state.selectedProjectIds.isNotEmpty()) {
-                        loadReposFor(state, state.selectedProjectIds.toList())
-                    }
+                    loadReposFor(state, effectiveSelection(state).toList())
                 }, ModalityState.any())
             } catch (e: Exception) {
                 logger.error("Failed to load projects for ${state.account.displayName}", e)
@@ -496,34 +490,60 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
         notifyDialogStateChanged()
     }
 
-    private fun updateProjectFilterButton(state: AccountState?) {
+    private fun updateProjectFilterField(state: AccountState?) {
         if (state == null || !state.projectsLoaded) {
-            projectFilterButton.text = "Loading…"
-            projectFilterButton.isEnabled = false
+            projectFilterField.setSelection(projectsLoaded = false, totalProjects = 0, selected = emptyList())
+            projectFilterField.isEnabled = false
             return
         }
-        projectFilterButton.text = ProjectFilterPopup.label(state.selectedProjectIds.size, state.projects.size)
-        projectFilterButton.isEnabled = state.projects.isNotEmpty()
+        val selected = state.projects.filter { it.id in state.selectedProjectIds }
+        projectFilterField.setSelection(
+            projectsLoaded = true,
+            totalProjects = state.projects.size,
+            selected = selected
+        )
+        projectFilterField.isEnabled = state.projects.isNotEmpty()
+    }
+
+    private fun removeProjectFromSelection(projectId: String) {
+        val state = currentAccountState() ?: return
+        if (!state.projectsLoaded) return
+        if (!state.selectedProjectIds.remove(projectId)) return
+        ProjectSelectionStore.save(state.account.id, state.selectedProjectIds)
+        updateProjectFilterField(state)
+        renderTree(state)
     }
 
     private fun openProjectFilterPopup() {
         val state = currentAccountState() ?: return
         if (!state.projectsLoaded) return
 
+        // Empty stored selection means "no filter" — open the popup with everything ticked
+        // so the user sees what's effectively in scope, not a misleadingly blank checklist.
+        val initiallySelected = effectiveSelection(state)
+
         ProjectFilterPopup.show(
-            anchor = projectFilterButton,
+            anchor = projectFilterField,
             projects = state.projects,
-            initiallySelected = state.selectedProjectIds
+            initiallySelected = initiallySelected
         ) { newSelection ->
             state.selectedProjectIds = newSelection.toMutableSet()
             ProjectSelectionStore.save(state.account.id, newSelection)
-            updateProjectFilterButton(state)
+            updateProjectFilterField(state)
             renderTree(state)
 
-            val toLoad = newSelection.filter { it !in state.repos && it !in state.loadingProjectIds }
-            if (toLoad.isNotEmpty()) loadReposFor(state, toLoad)
+            val toFetch = effectiveSelection(state).filter {
+                it !in state.repos && it !in state.loadingProjectIds
+            }
+            if (toFetch.isNotEmpty()) loadReposFor(state, toFetch)
         }
     }
+
+    /** Project ids that should currently be visible: the explicit selection, or every
+     *  project when the explicit selection is empty (= "no filter"). */
+    private fun effectiveSelection(state: AccountState): Set<String> =
+        if (state.selectedProjectIds.isEmpty()) state.projects.map { it.id }.toSet()
+        else state.selectedProjectIds.toSet()
 
     private fun currentAccountState(): AccountState? {
         val id = selectedAccount?.id ?: return null

--- a/src/main/kotlin/paol0b/azuredevops/checkout/AzureDevOpsCloneDialogComponent.kt
+++ b/src/main/kotlin/paol0b/azuredevops/checkout/AzureDevOpsCloneDialogComponent.kt
@@ -275,7 +275,6 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
         val targetDirectory = directoryField.text.trim()
 
         val cloneUrl = normalizeAzureDevOpsUrl(repo.remoteUrl)
-        val token = AzureDevOpsAccountManager.getInstance().getToken(account.id)
 
         val isShallowClone = shallowCloneCheckbox.isSelected
         val shallowDepth = shallowCloneDepthField.text.toIntOrNull() ?: 1
@@ -286,6 +285,7 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
             true
         ) {
             override fun run(indicator: ProgressIndicator) {
+                val token = AzureDevOpsAccountManager.getInstance().getToken(account.id)
                 try {
                     indicator.text = "Cloning repository from Azure DevOps..."
                     indicator.text2 = cloneUrl
@@ -401,16 +401,25 @@ class AzureDevOpsCloneDialogComponent(private val project: Project) : VcsCloneDi
             return
         }
 
-        val token = AzureDevOpsAccountManager.getInstance().getToken(account.id)
-        if (token == null) {
-            CloneTreeHelper.showEmptyState(rootNode, treeModel, "Authentication failed. Please re-login.")
-            updateProjectFilterField(null)
-            return
+        // PasswordSafe.get() does disk / OS-keychain I/O and is flagged as a slow op when
+        // called from the EDT — hop to a pooled thread for the token fetch, then come back
+        // to the EDT for the AccountState wiring.
+        CloneTreeHelper.showEmptyState(rootNode, treeModel, "Loading account…")
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val token = AzureDevOpsAccountManager.getInstance().getToken(account.id)
+            ApplicationManager.getApplication().invokeLater({
+                if (selectedAccount?.id != account.id) return@invokeLater  // user switched mid-fetch
+                if (token == null) {
+                    CloneTreeHelper.showEmptyState(rootNode, treeModel, "Authentication failed. Please re-login.")
+                    updateProjectFilterField(null)
+                    return@invokeLater
+                }
+                val state = AccountState(account, AzureDevOpsCloneApiClient(account.serverUrl, token))
+                accountStates[account.id] = state
+                updateProjectFilterField(state)
+                loadProjectsThenInitRepos(state)
+            }, ModalityState.any())
         }
-        val state = AccountState(account, AzureDevOpsCloneApiClient(account.serverUrl, token))
-        accountStates[account.id] = state
-        updateProjectFilterField(state)
-        loadProjectsThenInitRepos(state)
     }
 
     private fun loadProjectsThenInitRepos(state: AccountState) {

--- a/src/main/kotlin/paol0b/azuredevops/checkout/CloneTreeHelper.kt
+++ b/src/main/kotlin/paol0b/azuredevops/checkout/CloneTreeHelper.kt
@@ -56,12 +56,17 @@ object CloneTreeHelper {
             return
         }
 
+        // Empty [selectedProjectIds] is treated the same as null: show everything. An empty
+        // filter is "no filter applied", not "show nothing" — the latter would be confusing
+        // since the user has no other UI cue for why the tree is blank.
+        val activeFilter = selectedProjectIds?.takeIf { it.isNotEmpty() }
         val visibleProjects = projects
-            .filter { selectedProjectIds == null || it.id in selectedProjectIds }
+            .filter { activeFilter == null || it.id in activeFilter }
             .sortedBy { it.name.lowercase() }
 
         if (visibleProjects.isEmpty()) {
-            rootNode.add(DefaultMutableTreeNode("No projects selected. Use the Projects filter to pick some."))
+            // Only reachable if [selectedProjectIds] contains ids that no longer exist.
+            rootNode.add(DefaultMutableTreeNode("No matching projects"))
             treeModel.reload()
             return
         }

--- a/src/main/kotlin/paol0b/azuredevops/checkout/CloneTreeHelper.kt
+++ b/src/main/kotlin/paol0b/azuredevops/checkout/CloneTreeHelper.kt
@@ -27,84 +27,87 @@ object CloneTreeHelper {
     )
 
     /**
-     * Populates the tree from [data], sorting projects and repositories alphabetically
-     * and expanding all project nodes.
+     * Rebuilds the tree from the given snapshot.
+     *
+     * @param projects every project known for the current account
+     * @param repos repos indexed by project id (a project missing here is either still
+     *              loading — see [loadingProjectIds] — or simply has no repos)
+     * @param selectedProjectIds project ids the user wants visible. `null` means "all".
+     * @param loadingProjectIds project ids whose repo fetch is in flight; these get a
+     *                          "Loading repositories..." placeholder child node.
+     * @param searchText filter applied to repo names (and project names) within the
+     *                   already-resolved projects.
      */
-    fun populateTree(
+    fun render(
         rootNode: DefaultMutableTreeNode,
         treeModel: DefaultTreeModel,
         tree: Tree,
-        data: ProjectsData
+        projects: List<AzureDevOpsCloneApiClient.Project>,
+        repos: Map<String, List<AzureDevOpsCloneApiClient.Repository>>,
+        selectedProjectIds: Set<String>?,
+        loadingProjectIds: Set<String>,
+        searchText: String
     ) {
         rootNode.removeAllChildren()
 
-        if (data.projects.isEmpty()) {
+        if (projects.isEmpty()) {
             rootNode.add(DefaultMutableTreeNode("No projects found for this account"))
             treeModel.reload()
             return
         }
 
-        val sortedProjects = data.projects.sortedBy { it.name.lowercase() }
+        val visibleProjects = projects
+            .filter { selectedProjectIds == null || it.id in selectedProjectIds }
+            .sortedBy { it.name.lowercase() }
 
-        sortedProjects.forEach { proj ->
-            val projectNode = DefaultMutableTreeNode(proj)
-            rootNode.add(projectNode)
-
-            val repos = data.repositories[proj.id] ?: emptyList()
-            repos.sortedBy { it.name.lowercase() }.forEach { repo ->
-                val repoNode = DefaultMutableTreeNode(toAzureDevOpsRepository(repo, proj.name))
-                projectNode.add(repoNode)
-            }
-        }
-
-        treeModel.reload()
-
-        // Expand all projects
-        for (i in 0 until rootNode.childCount) {
-            tree.expandPath(TreePath(arrayOf(rootNode, rootNode.getChildAt(i))))
-        }
-    }
-
-    /**
-     * Filters the tree to show only projects/repos matching [searchText].
-     * If [searchText] is blank, delegates to [populateTree] to restore the full tree.
-     */
-    fun filterTree(
-        rootNode: DefaultMutableTreeNode,
-        treeModel: DefaultTreeModel,
-        tree: Tree,
-        data: ProjectsData,
-        searchText: String
-    ) {
-        val query = searchText.trim().lowercase()
-
-        if (query.isEmpty()) {
-            populateTree(rootNode, treeModel, tree, data)
+        if (visibleProjects.isEmpty()) {
+            rootNode.add(DefaultMutableTreeNode("No projects selected. Use the Projects filter to pick some."))
+            treeModel.reload()
             return
         }
 
-        rootNode.removeAllChildren()
+        val query = searchText.trim().lowercase()
 
-        data.projects.sortedBy { it.name.lowercase() }.forEach { proj ->
-            val repos = data.repositories[proj.id] ?: emptyList()
-            val matchingRepos = repos.filter { repo ->
-                repo.name.lowercase().contains(query) ||
-                    proj.name.lowercase().contains(query)
-            }.sortedBy { it.name.lowercase() }
+        visibleProjects.forEach { proj ->
+            val projectNameMatches = query.isEmpty() || proj.name.lowercase().contains(query)
+            val loading = proj.id in loadingProjectIds
+            val projectRepos = repos[proj.id].orEmpty()
 
-            if (matchingRepos.isNotEmpty()) {
-                val projectNode = DefaultMutableTreeNode(proj)
-                rootNode.add(projectNode)
+            val matchingRepos = projectRepos
+                .filter { repo ->
+                    query.isEmpty() ||
+                        projectNameMatches ||
+                        repo.name.lowercase().contains(query)
+                }
+                .sortedBy { it.name.lowercase() }
 
+            // Hide projects that contribute nothing under the current search (unless they're
+            // still loading — we want users to see them filling in).
+            if (!loading && matchingRepos.isEmpty() && query.isNotEmpty() && !projectNameMatches) {
+                return@forEach
+            }
+
+            val projectNode = DefaultMutableTreeNode(proj)
+            rootNode.add(projectNode)
+
+            if (loading) {
+                projectNode.add(DefaultMutableTreeNode("Loading repositories…"))
+            } else if (projectRepos.isEmpty()) {
+                projectNode.add(DefaultMutableTreeNode("No repositories"))
+            } else if (matchingRepos.isEmpty()) {
+                projectNode.add(DefaultMutableTreeNode("No matching repositories"))
+            } else {
                 matchingRepos.forEach { repo ->
                     projectNode.add(DefaultMutableTreeNode(toAzureDevOpsRepository(repo, proj.name)))
                 }
             }
         }
 
-        treeModel.reload()
+        if (rootNode.childCount == 0) {
+            rootNode.add(DefaultMutableTreeNode("No matches"))
+        }
 
-        // Expand all matching projects
+        treeModel.reload()
         for (i in 0 until rootNode.childCount) {
             tree.expandPath(TreePath(arrayOf(rootNode, rootNode.getChildAt(i))))
         }

--- a/src/main/kotlin/paol0b/azuredevops/checkout/ProjectFilterPopup.kt
+++ b/src/main/kotlin/paol0b/azuredevops/checkout/ProjectFilterPopup.kt
@@ -1,0 +1,155 @@
+package paol0b.azuredevops.checkout
+
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.openapi.ui.popup.JBPopupListener
+import com.intellij.openapi.ui.popup.LightweightWindowEvent
+import com.intellij.ui.CheckBoxList
+import com.intellij.ui.DocumentAdapter
+import com.intellij.ui.SearchTextField
+import com.intellij.ui.awt.RelativePoint
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.scale.JBUIScale
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import java.awt.Dimension
+import java.awt.FlowLayout
+import java.awt.Point
+import javax.swing.JButton
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.Timer
+import javax.swing.event.DocumentEvent
+
+/**
+ * Multi-select popup for picking which Azure DevOps projects should be loaded.
+ *
+ * Shows a search field, a checkbox list of every project, and Select All / Deselect All
+ * helpers. The final selection is delivered via [onApply] when the popup closes, so the
+ * caller can debounce repo fetching to one batch per popup interaction (not per click).
+ *
+ * The popup resizes itself to fit however many items the search filter matches (capped at
+ * [MAX_VISIBLE_ROWS]), and search-field typing is debounced so a fast typist doesn't
+ * trigger a rebuild on every keystroke.
+ */
+internal object ProjectFilterPopup {
+
+    private const val MAX_VISIBLE_ROWS = 14
+    private const val SEARCH_DEBOUNCE_MS = 200
+
+    fun show(
+        anchor: JComponent,
+        projects: List<AzureDevOpsCloneApiClient.Project>,
+        initiallySelected: Set<String>,
+        onApply: (Set<String>) -> Unit
+    ) {
+        val sortedProjects = projects.sortedBy { it.name.lowercase() }
+        val selection = HashSet(initiallySelected)
+
+        val checkBoxList = CheckBoxList<AzureDevOpsCloneApiClient.Project>()
+        checkBoxList.setCheckBoxListListener { index, value ->
+            val proj = checkBoxList.getItemAt(index) ?: return@setCheckBoxListListener
+            if (value) selection.add(proj.id) else selection.remove(proj.id)
+        }
+
+        val scrollPane = JBScrollPane(checkBoxList).apply {
+            border = JBUI.Borders.empty()
+        }
+
+        val popupWidth = JBUIScale.scale(320)
+
+        // The popup itself is created below; we hold the reference so [rebuild] can ask it
+        // to re-pack whenever the visible item count changes.
+        var currentPopup: com.intellij.openapi.ui.popup.JBPopup? = null
+
+        // Derived from the list's own preferred height after items are added, so the row
+        // height we use to size the popup matches whatever the current LAF/DPI is rendering
+        // (any constant we pick here tends to clip the last row at non-100% scaling).
+        fun computeScrollHeight(visibleCount: Int): Int {
+            if (visibleCount == 0) return JBUIScale.scale(40)
+            val listHeight = checkBoxList.preferredSize.height
+            val rowsToShow = visibleCount.coerceAtMost(MAX_VISIBLE_ROWS)
+            val perRow = (listHeight + visibleCount - 1) / visibleCount  // ceil per-row height
+            return rowsToShow * perRow + JBUIScale.scale(8)              // scroll-pane chrome
+        }
+
+        fun rebuild(filter: String) {
+            checkBoxList.clear()
+            val q = filter.trim().lowercase()
+            val visible = sortedProjects.filter { q.isEmpty() || it.name.lowercase().contains(q) }
+            visible.forEach { proj ->
+                checkBoxList.addItem(proj, proj.name, selection.contains(proj.id))
+            }
+            scrollPane.preferredSize = Dimension(popupWidth, computeScrollHeight(visible.size))
+            currentPopup?.pack(false, true)
+        }
+        rebuild("")
+
+        val searchField = SearchTextField(false).apply {
+            textEditor.emptyText.text = "Search projects"
+            textEditor.border = JBUI.Borders.empty(4)
+        }
+        val debounceTimer = Timer(SEARCH_DEBOUNCE_MS) { rebuild(searchField.text) }.apply {
+            isRepeats = false
+        }
+        searchField.addDocumentListener(object : DocumentAdapter() {
+            override fun textChanged(e: DocumentEvent) {
+                debounceTimer.restart()
+            }
+        })
+
+        val selectAll = JButton("Select All").apply {
+            addActionListener {
+                selection.clear()
+                selection.addAll(sortedProjects.map { it.id })
+                rebuild(searchField.text)
+            }
+        }
+        val deselectAll = JButton("Deselect All").apply {
+            addActionListener {
+                selection.clear()
+                rebuild(searchField.text)
+            }
+        }
+        val buttons = JPanel(FlowLayout(FlowLayout.LEFT, JBUIScale.scale(4), 0)).apply {
+            border = JBUI.Borders.empty(4)
+            add(selectAll)
+            add(deselectAll)
+        }
+
+        val content = JPanel(BorderLayout()).apply {
+            add(searchField, BorderLayout.NORTH)
+            add(scrollPane, BorderLayout.CENTER)
+            add(buttons, BorderLayout.SOUTH)
+        }
+
+        val popup = JBPopupFactory.getInstance()
+            .createComponentPopupBuilder(content, searchField.textEditor)
+            .setRequestFocus(true)
+            .setFocusable(true)
+            .setMovable(false)
+            .setResizable(true)
+            .setCancelOnClickOutside(true)
+            .setCancelOnWindowDeactivation(true)
+            .addListener(object : JBPopupListener {
+                override fun onClosed(event: LightweightWindowEvent) {
+                    debounceTimer.stop()
+                    onApply(selection.toSet())
+                }
+            })
+            .createPopup()
+        currentPopup = popup
+
+        val pt = RelativePoint(anchor, Point(0, anchor.height + JBUIScale.scale(2)))
+        popup.show(pt)
+    }
+
+    /**
+     * Helper for the trigger button label, e.g. "All projects", "5 of 27 projects", "No projects".
+     */
+    fun label(selectedCount: Int, totalCount: Int): String = when {
+        totalCount == 0 -> "No projects"
+        selectedCount == 0 -> "No projects selected"
+        selectedCount >= totalCount -> "All $totalCount projects"
+        else -> "$selectedCount of $totalCount projects"
+    }
+}

--- a/src/main/kotlin/paol0b/azuredevops/checkout/ProjectSelectionStore.kt
+++ b/src/main/kotlin/paol0b/azuredevops/checkout/ProjectSelectionStore.kt
@@ -1,0 +1,34 @@
+package paol0b.azuredevops.checkout
+
+import com.intellij.ide.util.PropertiesComponent
+
+/**
+ * Persists which Azure DevOps projects the user wants to load repos for, keyed by account id.
+ *
+ * Semantics:
+ *  - No stored entry for an account = first visit = treat as "all projects selected".
+ *  - Stored entry = exactly those project ids (an empty stored set is a deliberate choice).
+ *
+ * Stored at application level so the selection survives IDE restarts and is shared across
+ * projects (the accounts themselves are application-scoped too).
+ */
+internal object ProjectSelectionStore {
+    private fun key(accountId: String) = "azuredevops.clone.selectedProjects.$accountId"
+
+    fun isStored(accountId: String): Boolean =
+        PropertiesComponent.getInstance().isValueSet(key(accountId))
+
+    fun load(accountId: String): Set<String> {
+        val raw = PropertiesComponent.getInstance().getValue(key(accountId)) ?: return emptySet()
+        if (raw.isEmpty()) return emptySet()
+        return raw.split(',').filter { it.isNotBlank() }.toSet()
+    }
+
+    fun save(accountId: String, projectIds: Set<String>) {
+        PropertiesComponent.getInstance().setValue(key(accountId), projectIds.joinToString(","))
+    }
+
+    fun clear(accountId: String) {
+        PropertiesComponent.getInstance().unsetValue(key(accountId))
+    }
+}

--- a/src/main/kotlin/paol0b/azuredevops/checkout/RepositoryLoader.kt
+++ b/src/main/kotlin/paol0b/azuredevops/checkout/RepositoryLoader.kt
@@ -1,0 +1,59 @@
+package paol0b.azuredevops.checkout
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import java.util.concurrent.Semaphore
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Fetches repositories for a list of projects using a bounded number of concurrent HTTP calls.
+ *
+ * Callers receive each project's repos through [onLoaded] as soon as that call returns,
+ * which lets the clone dialog tree fill in incrementally instead of waiting for the whole
+ * org. [onAllDone] fires once every project has reported back (success or failure).
+ *
+ * Tasks dispatched into IntelliJ's pooled thread executor; concurrency is gated by a
+ * semaphore so we never have more than [concurrency] requests in flight at once.
+ */
+internal class RepositoryLoader(
+    private val apiClient: AzureDevOpsCloneApiClient,
+    concurrency: Int = DEFAULT_CONCURRENCY
+) {
+    private val logger = Logger.getInstance(RepositoryLoader::class.java)
+    private val semaphore = Semaphore(concurrency)
+
+    fun load(
+        projectIds: List<String>,
+        onLoaded: (projectId: String, repos: List<AzureDevOpsCloneApiClient.Repository>) -> Unit,
+        onFailed: (projectId: String, error: Throwable) -> Unit,
+        onAllDone: () -> Unit
+    ) {
+        if (projectIds.isEmpty()) {
+            onAllDone()
+            return
+        }
+
+        val remaining = AtomicInteger(projectIds.size)
+        projectIds.forEach { projectId ->
+            ApplicationManager.getApplication().executeOnPooledThread {
+                semaphore.acquire()
+                try {
+                    val repos = apiClient.getRepositoriesForProject(projectId)
+                    onLoaded(projectId, repos)
+                } catch (e: Throwable) {
+                    logger.warn("Failed to load repositories for project $projectId", e)
+                    onFailed(projectId, e)
+                } finally {
+                    semaphore.release()
+                    if (remaining.decrementAndGet() == 0) {
+                        onAllDone()
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val DEFAULT_CONCURRENCY = 8
+    }
+}

--- a/src/main/kotlin/paol0b/azuredevops/checkout/SelectedProjectsField.kt
+++ b/src/main/kotlin/paol0b/azuredevops/checkout/SelectedProjectsField.kt
@@ -1,0 +1,347 @@
+package paol0b.azuredevops.checkout
+
+import com.intellij.icons.AllIcons
+import com.intellij.ui.JBColor
+import com.intellij.ui.scale.JBUIScale
+import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
+import java.awt.BorderLayout
+import java.awt.Color
+import java.awt.Cursor
+import java.awt.Dimension
+import java.awt.Font
+import java.awt.Graphics
+import java.awt.Graphics2D
+import java.awt.Rectangle
+import java.awt.RenderingHints
+import java.awt.event.ComponentAdapter
+import java.awt.event.ComponentEvent
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import java.awt.geom.RoundRectangle2D
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.SwingConstants
+
+/**
+ * Combo-box-style field that visualizes the current project selection.
+ *
+ * Rendering modes, decided per layout pass based on the available width:
+ *  - **Loading**     no projects known yet, shows "Loading…" placeholder.
+ *  - **Placeholder** projects exist but none selected, shows a grayed italic prompt.
+ *  - **AllSelected** every project is selected, shows a single "All N projects" summary chip.
+ *  - **Chips**       a chip per selected project, each with a × to deselect.
+ *  - **Fallback**    chips don't fit, falls back to "X of Y projects selected" text.
+ *
+ * Click on the field body opens the popup (delegated via [onClick]); click on a chip's ×
+ * removes that project (delegated via [onRemove]).
+ */
+internal class SelectedProjectsField(
+    private val onClick: () -> Unit,
+    private val onRemove: (projectId: String) -> Unit
+) : JPanel(null) {
+
+    private companion object {
+        const val FIELD_HEIGHT_PX = 28
+        const val FIELD_PAD_PX = 6
+        const val CHIP_GAP_PX = 4
+        const val FIELD_ARC_PX = 6
+
+        val PLACEHOLDER_FG: JBColor = JBColor.namedColor(
+            "Label.disabledForeground",
+            JBColor(Color(150, 150, 150), Color(140, 140, 140))
+        )
+        val FIELD_BORDER: JBColor = JBColor.namedColor(
+            "Component.borderColor",
+            JBColor(Color(200, 200, 200), Color(70, 70, 70))
+        )
+        val FIELD_BG: JBColor = JBColor.namedColor(
+            "TextField.background",
+            JBColor(Color(255, 255, 255), Color(60, 63, 65))
+        )
+    }
+
+    // Forwards a click on any non-interactive child (labels, caret) to the field's onClick.
+    // Without this, clicks that happen to land directly on a JLabel are swallowed by the
+    // label and the popup never opens — user perceives this as "needs multiple clicks".
+    private val forwardClickToField = object : MouseAdapter() {
+        override fun mouseClicked(e: MouseEvent) {
+            if (isEnabled) onClick()
+        }
+    }
+
+    private val placeholderLabel = JLabel().apply {
+        foreground = PLACEHOLDER_FG
+        font = JBUI.Fonts.smallFont().deriveFont(Font.ITALIC)
+        isOpaque = false
+        cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+        addMouseListener(forwardClickToField)
+    }
+    private val fallbackLabel = JLabel().apply {
+        font = JBUI.Fonts.smallFont()
+        isOpaque = false
+        cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+        addMouseListener(forwardClickToField)
+    }
+    private val caretLabel = JLabel(AllIcons.General.ArrowDown).apply {
+        horizontalAlignment = SwingConstants.CENTER
+        cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+        addMouseListener(forwardClickToField)
+    }
+
+    private data class ChipModel(val projectId: String?, val text: String)
+
+    private var totalProjects = 0
+    private var projectsKnown = false
+    private var chipModels: List<ChipModel> = emptyList()
+
+    // Cached chip components so we don't re-create them on every resize.
+    private var chipCache: Map<ChipModel, Chip> = emptyMap()
+
+    init {
+        isOpaque = false
+        cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+
+        addMouseListener(object : MouseAdapter() {
+            override fun mouseClicked(e: MouseEvent) {
+                if (isEnabled) onClick()
+            }
+        })
+
+        addComponentListener(object : ComponentAdapter() {
+            override fun componentResized(e: ComponentEvent) {
+                revalidate()
+                repaint()
+            }
+        })
+    }
+
+    /**
+     * Updates the displayed selection.
+     *
+     * @param projectsLoaded false while the project list hasn't been fetched yet (shows
+     *                       a "Loading…" placeholder).
+     * @param totalProjects  total number of projects available for the current account.
+     * @param selected       projects currently selected, in display order.
+     */
+    fun setSelection(
+        projectsLoaded: Boolean,
+        totalProjects: Int,
+        selected: List<AzureDevOpsCloneApiClient.Project>
+    ) {
+        this.projectsKnown = projectsLoaded
+        this.totalProjects = totalProjects
+
+        val sorted = selected.sortedBy { it.name.lowercase() }
+        val newModels = sorted.map { ChipModel(it.id, it.name) }
+        chipModels = newModels
+
+        // Recycle existing chip components keyed by model so chip identity (and hover state)
+        // is preserved across no-op layouts.
+        val newCache = HashMap<ChipModel, Chip>(newModels.size)
+        for (model in newModels) {
+            newCache[model] = chipCache[model] ?: Chip(model)
+        }
+        chipCache = newCache
+
+        revalidate()
+        repaint()
+    }
+
+    override fun getPreferredSize(): Dimension =
+        Dimension(JBUIScale.scale(120), JBUIScale.scale(FIELD_HEIGHT_PX))
+
+    override fun getMinimumSize(): Dimension = preferredSize
+
+    override fun doLayout() {
+        removeAll()
+
+        val w = width
+        val h = height
+        if (w <= 0 || h <= 0) return
+
+        val pad = JBUIScale.scale(FIELD_PAD_PX)
+        val gap = JBUIScale.scale(CHIP_GAP_PX)
+
+        val caretSize = caretLabel.preferredSize
+        add(caretLabel)
+        caretLabel.bounds = Rectangle(
+            w - pad - caretSize.width,
+            (h - caretSize.height) / 2,
+            caretSize.width,
+            caretSize.height
+        )
+
+        val contentLeft = pad
+        val contentRight = w - pad - caretSize.width - pad
+        val contentW = contentRight - contentLeft
+        if (contentW <= 0) return
+
+        when {
+            !projectsKnown -> placeText(placeholderLabel, "Loading…", contentLeft, contentW, h)
+            totalProjects == 0 -> placeText(placeholderLabel, "No projects available", contentLeft, contentW, h)
+            // Empty selection = "no filter" = same display as "all selected".
+            chipModels.isEmpty() || chipModels.size >= totalProjects -> {
+                val summary = Chip(ChipModel(null, "All $totalProjects projects"))
+                val cw = summary.preferredSize.width.coerceAtMost(contentW)
+                val ch = summary.preferredSize.height
+                add(summary)
+                summary.bounds = Rectangle(contentLeft, (h - ch) / 2, cw, ch)
+            }
+            else -> {
+                val chips = chipModels.map { chipCache.getValue(it) }
+                var totalChipsW = 0
+                chips.forEachIndexed { i, chip ->
+                    if (i > 0) totalChipsW += gap
+                    totalChipsW += chip.preferredSize.width
+                }
+                if (totalChipsW <= contentW) {
+                    var x = contentLeft
+                    chips.forEach { chip ->
+                        val cw = chip.preferredSize.width
+                        val ch = chip.preferredSize.height
+                        add(chip)
+                        chip.bounds = Rectangle(x, (h - ch) / 2, cw, ch)
+                        x += cw + gap
+                    }
+                } else {
+                    placeText(
+                        fallbackLabel,
+                        "${chipModels.size} of $totalProjects projects selected",
+                        contentLeft, contentW, h
+                    )
+                }
+            }
+        }
+    }
+
+    private fun placeText(label: JLabel, text: String, x: Int, contentW: Int, fieldH: Int) {
+        label.text = text
+        add(label)
+        val labelH = label.preferredSize.height
+        label.bounds = Rectangle(x, (fieldH - labelH) / 2, contentW, labelH)
+    }
+
+    override fun paintComponent(g: Graphics) {
+        val g2 = g.create() as Graphics2D
+        try {
+            g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+            val arc = JBUIScale.scale(FIELD_ARC_PX).toDouble()
+            val shape = RoundRectangle2D.Double(
+                0.5, 0.5, (width - 1).toDouble(), (height - 1).toDouble(), arc, arc
+            )
+            g2.color = if (isEnabled) FIELD_BG else UIUtil.getPanelBackground()
+            g2.fill(shape)
+            g2.color = FIELD_BORDER
+            g2.draw(shape)
+        } finally {
+            g2.dispose()
+        }
+        super.paintComponent(g)
+    }
+
+    // ---- Inner chip ----
+
+    private inner class Chip(model: ChipModel) : JPanel(BorderLayout(JBUIScale.scale(2), 0)) {
+        private val projectId: String? = model.projectId
+        private var hovered = false
+
+        private val textLabel = JLabel(model.text).apply {
+            font = JBUI.Fonts.smallFont().deriveFont(Font.BOLD)
+            border = JBUI.Borders.empty(0, 6, 0, if (model.projectId == null) 6 else 0)
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+        }
+        private val closeLabel: JLabel? = if (model.projectId != null) {
+            JLabel(AllIcons.Actions.Close).apply {
+                cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+                border = JBUI.Borders.empty(0, 2, 0, 6)
+                toolTipText = "Remove from selection"
+            }
+        } else null
+
+        init {
+            isOpaque = false
+            cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+            add(textLabel, BorderLayout.CENTER)
+            closeLabel?.let { add(it, BorderLayout.EAST) }
+
+            // Hover state — tracked on the chip itself; the label children inherit it visually
+            // since they're drawn over the chip's painted background.
+            val hoverListener = object : MouseAdapter() {
+                override fun mouseEntered(e: MouseEvent) { hovered = true; repaint() }
+                override fun mouseExited(e: MouseEvent) {
+                    // Only un-hover when the mouse genuinely leaves the chip bounds — Swing
+                    // also fires mouseExited when crossing into a child, which would flicker.
+                    val pt = e.locationOnScreen
+                    if (isShowing) {
+                        val onScreen = locationOnScreen
+                        val inChip = pt.x in onScreen.x until (onScreen.x + width) &&
+                            pt.y in onScreen.y until (onScreen.y + height)
+                        if (inChip) return
+                    }
+                    hovered = false
+                    repaint()
+                }
+            }
+            addMouseListener(hoverListener)
+            textLabel.addMouseListener(hoverListener)
+            closeLabel?.addMouseListener(hoverListener)
+
+            // Click on the chip body (panel area or text label) opens the popup, just like
+            // clicking on the field itself.
+            val bodyClickListener = object : MouseAdapter() {
+                override fun mouseClicked(e: MouseEvent) {
+                    this@SelectedProjectsField.onClick()
+                }
+            }
+            addMouseListener(bodyClickListener)
+            textLabel.addMouseListener(bodyClickListener)
+
+            // The × icon: dedicated listener so the click never falls through to the body
+            // handler (which would re-open the popup right after we asked to remove).
+            if (closeLabel != null && projectId != null) {
+                closeLabel.addMouseListener(object : MouseAdapter() {
+                    override fun mouseClicked(e: MouseEvent) {
+                        this@SelectedProjectsField.onRemove(projectId)
+                    }
+                })
+            }
+        }
+
+        override fun getPreferredSize(): Dimension {
+            val pref = super.getPreferredSize()
+            return Dimension(pref.width, JBUIScale.scale(20))
+        }
+
+        override fun paintComponent(g: Graphics) {
+            val g2 = g.create() as Graphics2D
+            try {
+                g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+                val arc = JBUIScale.scale(5).toDouble()
+                val shape = RoundRectangle2D.Double(
+                    0.0, 0.0, (width - 1).toDouble(), (height - 1).toDouble(), arc, arc
+                )
+                g2.color = if (hovered) HOVER_BG else CHIP_BG
+                g2.fill(shape)
+                g2.color = CHIP_BORDER
+                g2.draw(shape)
+            } finally {
+                g2.dispose()
+            }
+            super.paintComponent(g)
+        }
+    }
+
+    private val CHIP_BG: JBColor = JBColor.namedColor(
+        "ActionButton.pressedBackground",
+        JBColor(Color(0, 0, 0, 30), Color(255, 255, 255, 25))
+    )
+    private val HOVER_BG: JBColor = JBColor.namedColor(
+        "ActionButton.hoverBackground",
+        JBColor(Color(0, 0, 0, 20), Color(255, 255, 255, 20))
+    )
+    private val CHIP_BORDER: JBColor = JBColor.namedColor(
+        "Component.borderColor",
+        JBColor(Color(200, 200, 200), Color(70, 70, 70))
+    )
+}

--- a/src/main/kotlin/paol0b/azuredevops/services/AzureDevOpsApiClient.kt
+++ b/src/main/kotlin/paol0b/azuredevops/services/AzureDevOpsApiClient.kt
@@ -35,7 +35,15 @@ class AzureDevOpsApiClient(private val project: Project) {
 
     companion object {
         private const val API_VERSION = "7.0"
-        
+
+        // Hard floor / ceiling for the configurable PR pagination, applied defensively
+        // regardless of what's in settings — guards against zero/negative values from a
+        // corrupted state file as well as absurdly large totals that could hang the IDE.
+        private const val PR_PAGE_SIZE_MIN = 50
+        private const val PR_PAGE_SIZE_MAX = 1000
+        private const val PR_MAX_TOTAL_MIN = 100
+        private const val PR_MAX_TOTAL_MAX = 20000
+
         private const val AUTH_ERROR_MESSAGE = """Authentication required. Please login:
 1. Go to File → Settings → Tools → Azure DevOps Accounts
 2. Click 'Add' button to add your account  
@@ -356,61 +364,258 @@ The plugin will automatically use your authenticated account for this repository
     }
 
     /**
-     * Retrieves the list of Pull Requests for the repository
+     * Retrieves the list of Pull Requests for the repository, paginating internally.
+     *
+     * Azure DevOps' `git/pullrequests` endpoint returns at most `$top` items per request and
+     * sometimes returns one less than asked when more pages exist (a known API quirk that is
+     * exactly why callers used to see "always 99" with `top = 100`). We paginate with `$skip`
+     * until we either run out of items or hit [top] as a safety cap.
+     *
      * @param status Filter by status (e.g., "active", "completed", "abandoned", "all")
-     * @param top Maximum number of PRs to retrieve
-     * @return List of Pull Requests
+     * @param top    Hard cap on the total number of PRs to accumulate across pages.
      */
     @Throws(AzureDevOpsApiException::class)
     fun getPullRequests(
         status: String = "active",
-        top: Int = 100
+        top: Int = effectiveMaxTotal()
     ): List<PullRequest> {
         val config = requireValidConfig()
-
         val statusParam = if (status == "all") "all" else status
-        val url = buildApiUrl(config.project, config.repository,
-            "/pullrequests?searchCriteria.status=$statusParam&\$top=$top&api-version=$API_VERSION")
-
-        logger.info("Fetching Pull Requests (status: $statusParam, top: $top)")
-        
-        return try {
-            val response = executeGet(url, config.personalAccessToken)
-            val listResponse = gson.fromJson(response, PullRequestListResponse::class.java)
-            listResponse.value
-        } catch (e: Exception) {
-            logger.error("Failed to fetch pull requests", e)
-            throw AzureDevOpsApiException("Error while retrieving Pull Requests: ${e.message}", e)
+        return paginatePullRequests(top, "(status: $statusParam, repo: ${config.repository})") { pageSize, skip ->
+            buildApiUrl(
+                config.project, config.repository,
+                "/pullrequests?searchCriteria.status=$statusParam&\$top=$pageSize&\$skip=$skip&api-version=$API_VERSION"
+            )
         }
     }
 
     /**
-     * Retrieves Pull Requests from all projects in the organization
-     * Uses the organization-level API to get PRs across all repositories
+     * Retrieves Pull Requests from every project in the organization, paginating internally.
+     *
+     * See [getPullRequests] for why we paginate; the org-wide endpoint exhibits the same
+     * "top - 1" behavior, which is exactly the cause of the project filter undercount (only
+     * projects whose PRs landed in the first 99 results showed up).
+     *
      * @param status Filter by status (e.g., "active", "completed", "abandoned", "all")
-     * @param top Maximum number of PRs to retrieve
-     * @return List of Pull Requests from all organization projects
+     * @param top    Hard cap on the total number of PRs to accumulate across pages.
      */
     @Throws(AzureDevOpsApiException::class)
     fun getAllOrganizationPullRequests(
         status: String = "active",
-        top: Int = 100
+        top: Int = effectiveMaxTotal()
     ): List<PullRequest> {
         val config = requireValidConfig()
-
         val statusParam = if (status == "all") "all" else status
-        val url = buildOrgApiUrl("/git/pullrequests?searchCriteria.status=$statusParam&\$top=$top&api-version=$API_VERSION")
+        return paginatePullRequests(top, "(status: $statusParam, org-wide)") { pageSize, skip ->
+            buildOrgApiUrl(
+                "/git/pullrequests?searchCriteria.status=$statusParam&\$top=$pageSize&\$skip=$skip&api-version=$API_VERSION"
+            )
+        }
+    }
 
-        logger.info("Fetching organization-wide Pull Requests (status: $statusParam, top: $top)")
+    /**
+     * Streaming variant of [getPullRequests]: invokes [onPage] after each page comes back so
+     * the UI can show repos progressively instead of waiting for the whole org. [onComplete]
+     * fires once when the loop exits, even if the result is empty.
+     *
+     * Both callbacks run on the calling thread — the caller is responsible for hopping to
+     * the EDT before touching UI state.
+     */
+    @Throws(AzureDevOpsApiException::class)
+    fun getPullRequestsStreaming(
+        status: String = "active",
+        top: Int = effectiveMaxTotal(),
+        onPage: (page: List<PullRequest>, accumulated: List<PullRequest>) -> Unit,
+        onComplete: (total: List<PullRequest>) -> Unit
+    ) {
+        val config = requireValidConfig()
+        val statusParam = if (status == "all") "all" else status
+        paginatePullRequestsStreaming(
+            maxTotal = top,
+            contextForLog = "(status: $statusParam, repo: ${config.repository})",
+            onPage = onPage,
+            onComplete = onComplete
+        ) { pageSize, skip ->
+            buildApiUrl(
+                config.project, config.repository,
+                "/pullrequests?searchCriteria.status=$statusParam&\$top=$pageSize&\$skip=$skip&api-version=$API_VERSION"
+            )
+        }
+    }
 
+    /** Streaming variant of [getAllOrganizationPullRequests]. See [getPullRequestsStreaming]. */
+    @Throws(AzureDevOpsApiException::class)
+    fun getAllOrganizationPullRequestsStreaming(
+        status: String = "active",
+        top: Int = effectiveMaxTotal(),
+        onPage: (page: List<PullRequest>, accumulated: List<PullRequest>) -> Unit,
+        onComplete: (total: List<PullRequest>) -> Unit
+    ) {
+        val statusParam = if (status == "all") "all" else status
+        paginatePullRequestsStreaming(
+            maxTotal = top,
+            contextForLog = "(status: $statusParam, org-wide)",
+            onPage = onPage,
+            onComplete = onComplete
+        ) { pageSize, skip ->
+            buildOrgApiUrl(
+                "/git/pullrequests?searchCriteria.status=$statusParam&\$top=$pageSize&\$skip=$skip&api-version=$API_VERSION"
+            )
+        }
+    }
+
+    /**
+     * Streaming, paginated PR fetch scoped to a single project (across every repo in that
+     * project). Lets the PR list filter avoid the org-wide endpoint when the user has
+     * narrowed the project filter down — we ask the server to do the filtering instead of
+     * pulling everything and discarding most of it.
+     */
+    @Throws(AzureDevOpsApiException::class)
+    fun getProjectPullRequestsStreaming(
+        projectIdOrName: String,
+        status: String = "active",
+        top: Int = effectiveMaxTotal(),
+        onPage: (page: List<PullRequest>, accumulated: List<PullRequest>) -> Unit,
+        onComplete: (total: List<PullRequest>) -> Unit
+    ) {
+        val configService = AzureDevOpsConfigService.getInstance(project)
+        val baseUrl = configService.getApiBaseUrl()
+        val encodedProject = encodePathSegment(projectIdOrName)
+        val statusParam = if (status == "all") "all" else status
+
+        paginatePullRequestsStreaming(
+            maxTotal = top,
+            contextForLog = "(status: $statusParam, project: $projectIdOrName)",
+            onPage = onPage,
+            onComplete = onComplete
+        ) { pageSize, skip ->
+            "$baseUrl/$encodedProject/_apis/git/pullrequests?searchCriteria.status=$statusParam&\$top=$pageSize&\$skip=$skip&api-version=$API_VERSION"
+        }
+    }
+
+    /** Summary of a project for the PR project filter. id is required (used for filtering),
+     *  name is the human-readable label, description is shown in the picker if non-blank. */
+    data class OrgProject(val id: String, val name: String, val description: String?)
+
+    /**
+     * Fetches every project in the organization. Used by the PR tool window to populate the
+     * project filter independently of which PRs happen to have been loaded, so a project with
+     * zero open PRs still shows up as a filter option.
+     */
+    @Throws(AzureDevOpsApiException::class)
+    fun getProjects(): List<OrgProject> {
+        val config = requireValidConfig()
+        val url = buildOrgApiUrl("/projects?api-version=$API_VERSION")
+        logger.info("Fetching projects for filter")
         return try {
             val response = executeGet(url, config.personalAccessToken)
-            val listResponse = gson.fromJson(response, PullRequestListResponse::class.java)
-            listResponse.value
+            val jsonObject = gson.fromJson(response, com.google.gson.JsonObject::class.java)
+            val out = mutableListOf<OrgProject>()
+            jsonObject.getAsJsonArray("value")?.forEach { element ->
+                val obj = element.asJsonObject
+                out.add(OrgProject(
+                    id = obj.get("id").asString,
+                    name = obj.get("name").asString,
+                    description = obj.get("description")?.takeIf { !it.isJsonNull }?.asString
+                ))
+            }
+            out
         } catch (e: Exception) {
-            logger.error("Failed to fetch organization pull requests", e)
-            throw AzureDevOpsApiException("Error while retrieving organization Pull Requests: ${e.message}", e)
+            logger.error("Failed to fetch projects", e)
+            throw AzureDevOpsApiException("Error while retrieving projects: ${e.message}", e)
         }
+    }
+
+    /**
+     * Shared pagination loop for the two PR listing endpoints. Stops when the server returns
+     * an empty page, when it returns only items we've already seen (defensive against unstable
+     * ordering across pages), or when [maxTotal] is reached.
+     *
+     * Uses received-count rather than requested-count for the `$skip` cursor so the ADO
+     * "$top - 1" quirk doesn't make us miss the next page. Returns the fully-accumulated list
+     * once the loop exits.
+     */
+    private fun paginatePullRequests(
+        maxTotal: Int,
+        contextForLog: String,
+        urlBuilder: (pageSize: Int, skip: Int) -> String
+    ): List<PullRequest> {
+        var result: List<PullRequest> = emptyList()
+        paginatePullRequestsStreaming(
+            maxTotal = maxTotal,
+            contextForLog = contextForLog,
+            onPage = { _, _ -> },
+            onComplete = { result = it },
+            urlBuilder = urlBuilder
+        )
+        return result
+    }
+
+    /**
+     * Returns the page-size from project settings, clamped to safe bounds so a corrupted
+     * state file (zero/negative/huge) can never break pagination.
+     */
+    private fun effectivePageSize(): Int {
+        val raw = AzureDevOpsSettingsService.getInstance(project).state.pullRequestPageSize
+        return raw.coerceIn(PR_PAGE_SIZE_MIN, PR_PAGE_SIZE_MAX)
+    }
+
+    /**
+     * Returns the safety cap on total PRs to accumulate, clamped to safe bounds. Used as the
+     * default value of `top` in the public PR listing methods.
+     */
+    private fun effectiveMaxTotal(): Int {
+        val raw = AzureDevOpsSettingsService.getInstance(project).state.pullRequestMaxTotal
+        return raw.coerceIn(PR_MAX_TOTAL_MIN, PR_MAX_TOTAL_MAX)
+    }
+
+    /**
+     * Underlying streaming pagination engine. Each page hands the caller two views:
+     *  - `page`: the new PRs from this round only.
+     *  - `accumulated`: an immutable snapshot of everything collected so far (already
+     *    deduped by `pullRequestId`).
+     * The snapshot is freshly copied each call so the caller can safely hand it off to
+     * another thread (e.g. [com.intellij.openapi.application.Application.invokeLater]).
+     */
+    private fun paginatePullRequestsStreaming(
+        maxTotal: Int,
+        contextForLog: String,
+        onPage: (page: List<PullRequest>, accumulated: List<PullRequest>) -> Unit,
+        onComplete: (total: List<PullRequest>) -> Unit,
+        urlBuilder: (pageSize: Int, skip: Int) -> String
+    ) {
+        val config = requireValidConfig()
+        val configuredPageSize = effectivePageSize()
+        val collected = mutableListOf<PullRequest>()
+        val seenIds = HashSet<Int>()
+        val maxHops = (maxTotal / configuredPageSize) * 2 + 5
+        var hops = 0
+
+        logger.info("Fetching Pull Requests $contextForLog (cap: $maxTotal, pageSize: $configuredPageSize)")
+
+        try {
+            while (collected.size < maxTotal && hops < maxHops) {
+                hops++
+                val remaining = maxTotal - collected.size
+                val pageSize = minOf(configuredPageSize, remaining)
+                val url = urlBuilder(pageSize, collected.size)
+                val response = executeGet(url, config.personalAccessToken)
+                val page = gson.fromJson(response, PullRequestListResponse::class.java).value
+                if (page.isEmpty()) break
+
+                val freshOnly = page.filter { seenIds.add(it.pullRequestId) }
+                if (freshOnly.isEmpty()) break
+                collected.addAll(freshOnly)
+
+                onPage(freshOnly, collected.toList())
+            }
+        } catch (e: Exception) {
+            logger.error("Failed to fetch pull requests $contextForLog after ${collected.size} collected", e)
+            throw AzureDevOpsApiException("Error while retrieving Pull Requests: ${e.message}", e)
+        }
+
+        onComplete(collected.toList())
+        logger.info("Fetched ${collected.size} Pull Requests $contextForLog in $hops page(s)")
     }
 
     /**

--- a/src/main/kotlin/paol0b/azuredevops/services/AzureDevOpsSettingsService.kt
+++ b/src/main/kotlin/paol0b/azuredevops/services/AzureDevOpsSettingsService.kt
@@ -20,7 +20,20 @@ class AzureDevOpsSettingsService(private val project: Project) : PersistentState
         var pullRequestIntervalSeconds: Long = 30,
         var commentsIntervalSeconds: Long = 15,
         var timelineIntervalSeconds: Long = 15,
-        var statusBarIntervalSeconds: Long = 60
+        var statusBarIntervalSeconds: Long = 60,
+
+        // --- PR list pagination ---
+        // pullRequestPageSize: how many PRs to ask Azure DevOps for per HTTP call.
+        // pullRequestMaxTotal: safety cap on the total accumulated across pages, so a
+        // misconfigured account or runaway loop can never blow up the IDE on huge orgs.
+        var pullRequestPageSize: Int = 200,
+        var pullRequestMaxTotal: Int = 2000,
+
+        // --- PR list project filter ---
+        // Project ids that the user has chosen to scope the PR list to. Empty means
+        // "no filter — use the org-wide/repo-scoped endpoint as before". Persisted across
+        // restarts so the user's narrowed view of a large org is restored on reopen.
+        var prFilterSelectedProjectIds: MutableList<String> = mutableListOf()
     )
 
     private var myState = State()

--- a/src/main/kotlin/paol0b/azuredevops/toolwindow/PullRequestListPanel.kt
+++ b/src/main/kotlin/paol0b/azuredevops/toolwindow/PullRequestListPanel.kt
@@ -18,6 +18,7 @@ import paol0b.azuredevops.actions.SetAutoCompletePullRequestAction
 import paol0b.azuredevops.model.PullRequest
 import paol0b.azuredevops.services.AvatarService
 import paol0b.azuredevops.services.AzureDevOpsApiClient
+import paol0b.azuredevops.services.AzureDevOpsSettingsService
 import paol0b.azuredevops.toolwindow.filters.PullRequestFilterPanel
 import paol0b.azuredevops.toolwindow.filters.PullRequestSearchValue
 import java.awt.BorderLayout
@@ -25,6 +26,7 @@ import java.awt.Dimension
 import java.awt.Font
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
+import java.util.concurrent.atomic.AtomicLong
 import javax.swing.*
 
 /**
@@ -47,6 +49,12 @@ class PullRequestListPanel(
     private var lastLoadedPullRequests: List<PullRequest> = emptyList()
     private var isErrorState: Boolean = false
     private var currentUserId: String? = null
+
+    // Each refresh increments this; streaming page/complete callbacks compare their captured
+    // generation against the current one and silently no-op if the user has since triggered
+    // another refresh. Without this, late pages from an aborted load would clobber the new
+    // results.
+    private val refreshGeneration = AtomicLong(0)
 
     // Derived from filter panel state
     private var currentSearchValue = PullRequestSearchValue.DEFAULT
@@ -97,6 +105,17 @@ class PullRequestListPanel(
             onFilterChanged(newFilter)
         }
 
+        // Restore the persisted project filter selection so the very first refresh already
+        // scopes to the projects the user last cared about, instead of re-fetching everything
+        // and then narrowing once the filter chip wakes up.
+        val persistedProjectIds = AzureDevOpsSettingsService.getInstance(project).state
+            .prFilterSelectedProjectIds
+            .toSet()
+        if (persistedProjectIds.isNotEmpty()) {
+            currentSearchValue = currentSearchValue.copy(selectedProjectIds = persistedProjectIds)
+            filterPanel.setInitialFilter(currentSearchValue)
+        }
+
         val scrollPane = JBScrollPane(prList).apply {
             border = JBUI.Borders.empty()
             verticalScrollBar.unitIncrement = 16
@@ -118,9 +137,16 @@ class PullRequestListPanel(
     private fun onFilterChanged(newValue: PullRequestSearchValue) {
         val statusChanged = currentSearchValue.state != newValue.state
         val orgChanged = currentSearchValue.showAllOrg != newValue.showAllOrg
+        val projectsChanged = currentSearchValue.selectedProjectIds != newValue.selectedProjectIds
         currentSearchValue = newValue
 
-        if (statusChanged || orgChanged) {
+        if (projectsChanged) {
+            // Persist immediately so a hard restart preserves the user's narrowed view.
+            AzureDevOpsSettingsService.getInstance(project).state.prFilterSelectedProjectIds =
+                newValue.selectedProjectIds.toMutableList()
+        }
+
+        if (statusChanged || orgChanged || projectsChanged) {
             refreshPullRequests()
         } else {
             applyClientFilters()
@@ -128,6 +154,7 @@ class PullRequestListPanel(
     }
 
     fun refreshPullRequests() {
+        val generation = refreshGeneration.incrementAndGet()
         statusLabel.text = "Loading Pull Requests..."
         statusLabel.icon = AllIcons.Process.Step_1
 
@@ -142,25 +169,66 @@ class PullRequestListPanel(
                 indicator.isIndeterminate = true
                 try {
                     val apiClient = AzureDevOpsApiClient.getInstance(project)
-                    val pullRequests = if (showAllOrg) {
-                        apiClient.getAllOrganizationPullRequests(status = apiStatus, top = 100)
-                    } else {
-                        apiClient.getPullRequests(status = apiStatus)
-                    }
                     val resolvedCurrentUserId = apiClient.getCurrentUserIdCached()
 
-                    ApplicationManager.getApplication().invokeLater {
-                        currentUserId = resolvedCurrentUserId
-                        cachedPullRequests = pullRequests
-                        lastLoadedPullRequests = pullRequests
-                        filterPanel.updateAuthorsFromPullRequests(pullRequests)
-                        val filtered = applyAllFilters(pullRequests)
-                        updateList(filtered, selectedPrId)
-                        updateStatusLabel(filtered.size, pullRequests.size)
-                        isErrorState = false
+                    val onPage: (List<PullRequest>, List<PullRequest>) -> Unit = { _, accumulated ->
+                        ApplicationManager.getApplication().invokeLater {
+                            if (refreshGeneration.get() != generation) return@invokeLater
+                            applyStreamingUpdate(
+                                accumulated = accumulated,
+                                resolvedCurrentUserId = resolvedCurrentUserId,
+                                originalSelectedPrId = selectedPrId,
+                                isFinal = false
+                            )
+                        }
+                    }
+
+                    val onComplete: (List<PullRequest>) -> Unit = { total ->
+                        ApplicationManager.getApplication().invokeLater {
+                            if (refreshGeneration.get() != generation) return@invokeLater
+                            applyStreamingUpdate(
+                                accumulated = total,
+                                resolvedCurrentUserId = resolvedCurrentUserId,
+                                originalSelectedPrId = selectedPrId,
+                                isFinal = true
+                            )
+                        }
+                    }
+
+                    val selectedProjectIds = currentSearchValue.selectedProjectIds
+                    when {
+                        // Per-project server-side scoping: fetch only the projects the user
+                        // selected, sequentially. Pages from each project flow into the same
+                        // aggregated list so the UI fills in across project boundaries.
+                        selectedProjectIds.isNotEmpty() -> {
+                            val aggregated = mutableListOf<PullRequest>()
+                            val seenIds = HashSet<Int>()
+                            selectedProjectIds.forEach { projectId ->
+                                apiClient.getProjectPullRequestsStreaming(
+                                    projectIdOrName = projectId,
+                                    status = apiStatus,
+                                    onPage = { page, _ ->
+                                        val fresh = page.filter { seenIds.add(it.pullRequestId) }
+                                        aggregated.addAll(fresh)
+                                        onPage(fresh, aggregated.toList())
+                                    },
+                                    // Per-project complete is intentionally a no-op — the
+                                    // aggregated onComplete fires once after every project.
+                                    onComplete = { /* aggregated below */ }
+                                )
+                            }
+                            onComplete(aggregated.toList())
+                        }
+                        showAllOrg -> apiClient.getAllOrganizationPullRequestsStreaming(
+                            status = apiStatus, onPage = onPage, onComplete = onComplete
+                        )
+                        else -> apiClient.getPullRequestsStreaming(
+                            status = apiStatus, onPage = onPage, onComplete = onComplete
+                        )
                     }
                 } catch (e: Exception) {
                     ApplicationManager.getApplication().invokeLater {
+                        if (refreshGeneration.get() != generation) return@invokeLater
                         isErrorState = true
                         listModel.clear()
                         val isConfigError = e.message?.contains("not configured", ignoreCase = true) == true
@@ -175,6 +243,38 @@ class PullRequestListPanel(
                 }
             }
         })
+    }
+
+    /**
+     * Folds the latest streaming snapshot into the panel state on the EDT.
+     *
+     * Called once per arriving page (with `isFinal = false`) and once more when pagination
+     * exits (with `isFinal = true`). The list is rebuilt from scratch each call rather than
+     * appended-to because sort/filter outcomes can depend on the full set (e.g. an "oldest
+     * first" sort puts newly-arrived older PRs at the top).
+     */
+    private fun applyStreamingUpdate(
+        accumulated: List<PullRequest>,
+        resolvedCurrentUserId: String?,
+        originalSelectedPrId: Int?,
+        isFinal: Boolean
+    ) {
+        currentUserId = resolvedCurrentUserId
+        cachedPullRequests = accumulated
+        lastLoadedPullRequests = accumulated
+        filterPanel.updateAuthorsFromPullRequests(accumulated)
+        val filtered = applyAllFilters(accumulated)
+        // Prefer the user's live selection if they've clicked something while loading;
+        // otherwise restore the selection captured at the start of this refresh.
+        val selectionToRestore = getSelectedPullRequest()?.pullRequestId ?: originalSelectedPrId
+        updateList(filtered, selectionToRestore)
+        if (isFinal) {
+            updateStatusLabel(filtered.size, accumulated.size)
+        } else {
+            statusLabel.icon = AllIcons.Process.Step_1
+            statusLabel.text = "Loading Pull Requests… ${accumulated.size} so far"
+        }
+        isErrorState = false
     }
 
     fun getSelectedPullRequest(): PullRequest? = prList.selectedValue
@@ -214,11 +314,13 @@ class PullRequestListPanel(
             }
         }
 
-        // Project filter
-        val projFilter = sv.projectFilter
-        if (projFilter != null) {
+        // Project filter (defensive — the server has already done the filtering for the
+        // per-project fetch path, but this also covers the org-wide / repo-scoped paths
+        // and keeps applyClientFilters() correct if only the project chip changed).
+        val projectIds = sv.selectedProjectIds
+        if (projectIds.isNotEmpty()) {
             result = result.filter { pr ->
-                pr.repository?.project?.id == projFilter.id || pr.repository?.project?.name == projFilter.name
+                pr.repository?.project?.id in projectIds
             }
         }
 

--- a/src/main/kotlin/paol0b/azuredevops/toolwindow/filters/PullRequestFilterPanel.kt
+++ b/src/main/kotlin/paol0b/azuredevops/toolwindow/filters/PullRequestFilterPanel.kt
@@ -2,6 +2,8 @@ package paol0b.azuredevops.toolwindow.filters
 
 import com.intellij.icons.AllIcons
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.ModalityState
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.ui.JBColor
 import com.intellij.ui.SearchTextField
@@ -14,8 +16,11 @@ import com.intellij.openapi.ui.popup.PopupStep
 import com.intellij.openapi.ui.popup.util.BaseListPopupStep
 import com.intellij.ui.awt.RelativePoint
 import com.intellij.util.ui.JBUI
+import paol0b.azuredevops.checkout.AzureDevOpsCloneApiClient
+import paol0b.azuredevops.checkout.ProjectFilterPopup
 import paol0b.azuredevops.model.PullRequest
 import paol0b.azuredevops.services.AvatarService
+import paol0b.azuredevops.services.AzureDevOpsApiClient
 import java.awt.*
 import javax.swing.*
 
@@ -52,10 +57,34 @@ class PullRequestFilterPanel(
     private val filterBadgeIcon = FilterBadgeIcon(AllIcons.General.Filter)
     private val quickFilterButton: JButton
 
-    // Cached lists (populated from loaded PR data)
+    // Cached lists. Authors and repositories are still derived from loaded PR data (the
+    // filter values are only meaningful for things that actually appear in PRs). Projects,
+    // however, are pre-fetched directly from the org's projects endpoint so the user can
+    // pick any project — even one with zero PRs in the current state — to narrow the load.
+    //
+    // We keep two sources for projects: the authoritative API list, and a fallback derived
+    // from loaded PRs. If the API call fails (commonly: PAT missing the `vso.project` /
+    // "Project and Team (read)" scope) we still want the multi-select popup to be usable
+    // — populated from whatever projects the user's PRs already revealed.
     private var cachedAuthors: List<PullRequestSearchValue.AuthorFilter>? = null
-    private var cachedProjects: List<PullRequestSearchValue.ProjectFilter> = emptyList()
+    private var orgProjectsFromApi: List<AzureDevOpsApiClient.OrgProject> = emptyList()
+    // Keyed by project id, kept as an accumulating union across every refresh — once we've
+    // seen a project from a PR, it stays in the fallback even if a later (narrower) refresh
+    // doesn't include it. Without this, narrowing the project filter would visibly shrink
+    // the list of projects available in the chip on the next refresh.
+    private val projectsFromPrData: MutableMap<String, AzureDevOpsApiClient.OrgProject> = mutableMapOf()
     private var cachedRepositories: List<PullRequestSearchValue.RepositoryFilter> = emptyList()
+
+    private val logger = Logger.getInstance(PullRequestFilterPanel::class.java)
+
+    private enum class LoadState { NOT_STARTED, LOADING, LOADED, FAILED }
+    private var orgProjectsLoadState: LoadState = LoadState.NOT_STARTED
+
+    /** Combined view: prefer the authoritative API list; fall back to the accumulated
+     *  PR-derived list if empty. The fallback is sorted alphabetically by project name. */
+    private val effectiveProjects: List<AzureDevOpsApiClient.OrgProject>
+        get() = if (orgProjectsFromApi.isNotEmpty()) orgProjectsFromApi
+        else projectsFromPrData.values.sortedBy { it.name.lowercase() }
 
     init {
         // Create quick filter button (funnel icon)
@@ -81,10 +110,14 @@ class PullRequestFilterPanel(
         // Set default state
         stateChip.setValue(PullRequestSearchValue.State.OPEN.displayName)
 
-        // Project filter
+        // Project filter (multi-select). Clearing the chip wipes both project ids and the
+        // dependent repository filter, since "all projects" no longer constrains repos.
         projectChip = FilterChipComponent("Project",
             onShowPopup = { chip -> showProjectPopup(chip) },
-            onClear = { updateFilter(currentValue.copy(projectFilter = null, repositoryFilter = null)); repositoryChip.clearValue() }
+            onClear = {
+                updateFilter(currentValue.copy(selectedProjectIds = emptySet(), repositoryFilter = null))
+                repositoryChip.clearValue()
+            }
         )
 
         // Repository filter
@@ -158,11 +191,56 @@ class PullRequestFilterPanel(
             add(searchField, BorderLayout.CENTER)
             add(filterBar, BorderLayout.SOUTH)
         }
+
+        // Kick off the projects fetch on construction so the filter popup is ready to use
+        // by the time the user actually clicks it. Failures are non-fatal — the popup will
+        // just show a "no projects" message until the next reload.
+        fetchOrgProjectsAsync()
     }
 
     fun getComponent(): JPanel = panel
 
     fun getCurrentFilter(): PullRequestSearchValue = currentValue
+
+    /**
+     * Replaces the panel's filter value without firing [onFilterChanged]. Used by the list
+     * panel at startup to restore the persisted project selection before the first refresh
+     * runs, so that refresh already knows which projects to scope to.
+     */
+    fun setInitialFilter(value: PullRequestSearchValue) {
+        currentValue = value
+        syncChipsFromValue()
+        updateBadge()
+    }
+
+    private fun fetchOrgProjectsAsync() {
+        // Don't pile up concurrent fetches.
+        if (orgProjectsLoadState == LoadState.LOADING) return
+        orgProjectsLoadState = LoadState.LOADING
+
+        ApplicationManager.getApplication().executeOnPooledThread {
+            var result: List<AzureDevOpsApiClient.OrgProject> = emptyList()
+            var failure: Throwable? = null
+            try {
+                result = AzureDevOpsApiClient.getInstance(project).getProjects()
+            } catch (e: Throwable) {
+                failure = e
+                logger.warn(
+                    "Failed to fetch projects for PR filter; falling back to PR-derived list. " +
+                        "If you expected the full project list, ensure your PAT has the " +
+                        "'Project and Team (read)' (vso.project) scope.",
+                    e
+                )
+            }
+            ApplicationManager.getApplication().invokeLater({
+                orgProjectsFromApi = result
+                orgProjectsLoadState = if (failure != null) LoadState.FAILED else LoadState.LOADED
+                // The chip label may have been a count placeholder from a persisted selection
+                // before names were known — refresh it once we have data.
+                syncProjectChipFromValue()
+            }, ModalityState.any())
+        }
+    }
 
     /**
      * Update the cached list of authors from the loaded PR data.
@@ -184,20 +262,29 @@ class PullRequestFilterPanel(
             .sortedBy { it.displayName.lowercase() }
         cachedAuthors = authors
 
-        // Extract distinct projects from PR data
-        cachedProjects = pullRequests
-            .mapNotNull { pr ->
-                pr.repository?.project?.let { proj ->
-                    PullRequestSearchValue.ProjectFilter(
-                        id = proj.id,
-                        name = proj.name ?: "Unknown"
-                    )
-                }
+        // Still derive a PR-data project list as a fallback. The authoritative source for
+        // the filter popup is the API list (see fetchOrgProjectsAsync) — that one covers
+        // projects with zero PRs — but if the API call failed (e.g. PAT lacks the project
+        // scope) we want to keep the popup functional with whatever projects the loaded PRs
+        // have ever revealed. We MERGE into the existing map rather than replacing so that
+        // a narrower refresh (e.g. after the user filters down to 3 projects) doesn't
+        // visibly shrink the list of projects available in the chip.
+        pullRequests.forEach { pr ->
+            val proj = pr.repository?.project
+            val id = proj?.id
+            val name = proj?.name
+            if (id != null && name != null) {
+                projectsFromPrData.putIfAbsent(id, AzureDevOpsApiClient.OrgProject(id, name, null))
             }
-            .distinctBy { it.id ?: it.name }
-            .sortedBy { it.name.lowercase() }
+        }
 
-        // Extract distinct repositories from PR data
+        // If the org projects fetch previously failed, give it another shot now that PR
+        // loading is clearly working — credentials may have been refreshed, or the failure
+        // may have been transient.
+        if (orgProjectsLoadState == LoadState.FAILED) {
+            fetchOrgProjectsAsync()
+        }
+
         cachedRepositories = pullRequests
             .mapNotNull { pr ->
                 pr.repository?.let { repo ->
@@ -358,34 +445,62 @@ class PullRequestFilterPanel(
     }
 
     private fun showProjectPopup(chip: FilterChipComponent) {
-        if (cachedProjects.isEmpty()) {
+        val available = effectiveProjects
+
+        // If we have nothing yet, surface a state-appropriate message and (re)kick off a
+        // fetch — that way a user who opens the popup before the eager init fetch had a
+        // chance to complete, or whose first attempt failed, doesn't get stuck staring at
+        // a static "Loading…" forever.
+        if (available.isEmpty()) {
+            when (orgProjectsLoadState) {
+                LoadState.NOT_STARTED, LoadState.FAILED -> fetchOrgProjectsAsync()
+                LoadState.LOADING, LoadState.LOADED -> Unit
+            }
+            val message = when (orgProjectsLoadState) {
+                LoadState.LOADING -> "Loading projects… open this menu again in a moment"
+                LoadState.FAILED -> "Failed to load projects (check idea.log) — retrying…"
+                LoadState.NOT_STARTED -> "Loading projects…"
+                LoadState.LOADED -> "No projects available"
+            }
             FilterPopupUtil.showSimplePopup(
                 component = chip,
-                items = listOf("No projects available"),
+                items = listOf(message),
                 presenter = { it },
                 onSelected = {}
             )
             return
         }
-        FilterPopupUtil.showSearchablePopup(
-            component = chip,
-            items = cachedProjects,
-            presenter = { it.name },
-            icon = AllIcons.Nodes.Project,
-            onSelected = { proj ->
-                chip.setValue(proj.name)
-                // When project changes, clear repository filter since repos may differ
-                repositoryChip.clearValue()
-                updateFilter(currentValue.copy(projectFilter = proj, repositoryFilter = null))
+
+        // ProjectFilterPopup (used by the clone dialog) wants its own Project type — convert
+        // each OrgProject to that shape so we can reuse the multi-select popup verbatim.
+        val popupProjects = available.map {
+            AzureDevOpsCloneApiClient.Project(id = it.id, name = it.name, description = it.description)
+        }
+        ProjectFilterPopup.show(
+            anchor = chip,
+            projects = popupProjects,
+            initiallySelected = currentValue.selectedProjectIds
+        ) { newSelection ->
+            // Project selection invalidates any repo selection (the chosen repo may no
+            // longer be in any selected project).
+            val newRepo = currentValue.repositoryFilter?.takeIf { repo ->
+                newSelection.isEmpty() || available
+                    .filter { it.id in newSelection }
+                    .any { it.name == repo.projectName }
             }
-        )
+            if (newRepo == null) repositoryChip.clearValue()
+            updateFilter(currentValue.copy(selectedProjectIds = newSelection, repositoryFilter = newRepo))
+            syncProjectChipFromValue()
+        }
     }
 
     private fun showRepositoryPopup(chip: FilterChipComponent) {
-        // If a project filter is active, only show repos from that project
-        val repos = currentValue.projectFilter?.let { proj ->
-            cachedRepositories.filter { it.projectName == proj.name }
-        } ?: cachedRepositories
+        // Constrain the repo list to the projects the user has explicitly selected (if any).
+        val selectedProjectNames = if (currentValue.selectedProjectIds.isNotEmpty()) {
+            effectiveProjects.filter { it.id in currentValue.selectedProjectIds }.map { it.name }.toSet()
+        } else emptySet()
+        val repos = if (selectedProjectNames.isEmpty()) cachedRepositories
+        else cachedRepositories.filter { it.projectName in selectedProjectNames }
 
         if (repos.isEmpty()) {
             FilterPopupUtil.showSimplePopup(
@@ -400,7 +515,7 @@ class PullRequestFilterPanel(
             component = chip,
             items = repos,
             presenter = { repo ->
-                if (currentValue.projectFilter == null && repo.projectName != null) {
+                if (selectedProjectNames.isEmpty() && repo.projectName != null) {
                     "${repo.name}  (${repo.projectName})"
                 } else {
                     repo.name
@@ -412,6 +527,19 @@ class PullRequestFilterPanel(
                 updateFilter(currentValue.copy(repositoryFilter = repo))
             }
         )
+    }
+
+    /** Sets the project chip's label to match the current [PullRequestSearchValue.selectedProjectIds]. */
+    private fun syncProjectChipFromValue() {
+        val ids = currentValue.selectedProjectIds
+        when {
+            ids.isEmpty() -> projectChip.clearValue()
+            ids.size == 1 -> {
+                val name = effectiveProjects.firstOrNull { it.id in ids }?.name ?: "1 project"
+                projectChip.setValue(name)
+            }
+            else -> projectChip.setValue("${ids.size} projects")
+        }
     }
 
     private fun updateFilter(newValue: PullRequestSearchValue) {
@@ -453,11 +581,7 @@ class PullRequestFilterPanel(
             sortChip.clearValue()
         }
 
-        if (v.projectFilter != null) {
-            projectChip.setValue(v.projectFilter.name)
-        } else {
-            projectChip.clearValue()
-        }
+        syncProjectChipFromValue()
 
         if (v.repositoryFilter != null) {
             repositoryChip.setValue(v.repositoryFilter.name)
@@ -480,7 +604,7 @@ class PullRequestFilterPanel(
         if (currentValue.author != null) count++
         if (currentValue.review != null) count++
         if (currentValue.sort != null) count++
-        if (currentValue.projectFilter != null) count++
+        if (currentValue.selectedProjectIds.isNotEmpty()) count++
         if (currentValue.repositoryFilter != null) count++
         if (currentValue.searchQuery != null) count++
         return count

--- a/src/main/kotlin/paol0b/azuredevops/toolwindow/filters/PullRequestSearchValue.kt
+++ b/src/main/kotlin/paol0b/azuredevops/toolwindow/filters/PullRequestSearchValue.kt
@@ -10,7 +10,9 @@ data class PullRequestSearchValue(
     val author: AuthorFilter? = null,
     val review: ReviewState? = null,
     val sort: Sort? = null,
-    val projectFilter: ProjectFilter? = null,
+    /** Multi-select set of project ids the user has chosen. Empty = no project filter (the
+     *  list panel falls back to its org-wide or repo-scoped fetch behavior). */
+    val selectedProjectIds: Set<String> = emptySet(),
     val repositoryFilter: RepositoryFilter? = null,
     val showAllOrg: Boolean = false
 ) {
@@ -22,7 +24,7 @@ data class PullRequestSearchValue(
             if (author != null) count++
             if (review != null) count++
             if (sort != null) count++
-            if (projectFilter != null) count++
+            if (selectedProjectIds.isNotEmpty()) count++
             if (repositoryFilter != null) count++
             return count
         }

--- a/src/main/kotlin/paol0b/azuredevops/ui/AzureDevOpsProjectConfigurable.kt
+++ b/src/main/kotlin/paol0b/azuredevops/ui/AzureDevOpsProjectConfigurable.kt
@@ -41,6 +41,12 @@ class AzureDevOpsProjectConfigurable(private val project: Project) : Configurabl
     private val timelineIntervalSpinner = JSpinner(SpinnerNumberModel(15L, 5L, 120L, 5L))
     private val statusBarIntervalSpinner = JSpinner(SpinnerNumberModel(60L, 15L, 300L, 15L))
 
+    // Pull request loading spinners. Bounds mirror AzureDevOpsApiClient's PR_PAGE_SIZE_*
+    // / PR_MAX_TOTAL_* clamps so the spinner UI can't produce a value the client would
+    // silently coerce.
+    private val prPageSizeSpinner = JSpinner(SpinnerNumberModel(200, 50, 1000, 50))
+    private val prMaxTotalSpinner = JSpinner(SpinnerNumberModel(2000, 100, 20000, 100))
+
     data class AccountItem(
         val account: AzureDevOpsAccount?,
         val displayText: String
@@ -104,6 +110,8 @@ class AzureDevOpsProjectConfigurable(private val project: Project) : Configurabl
         commentsIntervalSpinner.value = settings.commentsIntervalSeconds
         timelineIntervalSpinner.value = settings.timelineIntervalSeconds
         statusBarIntervalSpinner.value = settings.statusBarIntervalSeconds
+        prPageSizeSpinner.value = settings.pullRequestPageSize
+        prMaxTotalSpinner.value = settings.pullRequestMaxTotal
 
         val formBuilder = FormBuilder.createFormBuilder()
             // --- Repository & Account ---
@@ -128,6 +136,17 @@ class AzureDevOpsProjectConfigurable(private val project: Project) : Configurabl
             .addLabeledComponent(JBLabel("Comments (seconds):"), commentsIntervalSpinner, 1, false)
             .addLabeledComponent(JBLabel("Timeline (seconds):"), timelineIntervalSpinner, 1, false)
             .addLabeledComponent(JBLabel("Status Bar (seconds):"), statusBarIntervalSpinner, 1, false)
+            // --- PR list loading ---
+            .addVerticalGap(15)
+            .addComponent(JBLabel("<html><b>Pull Request List Loading</b></html>"))
+            .addComponent(JBLabel("<html><font size='-1' color='gray'>" +
+                "Controls how the PR tool window paginates fetches. Page size is the batch " +
+                "fetched per HTTP call; max total is the safety cap on the entire list. " +
+                "Larger values mean fewer requests but slower first paint." +
+                "</font></html>"), 1)
+            .addVerticalGap(5)
+            .addLabeledComponent(JBLabel("Page size (PRs per request):"), prPageSizeSpinner, 1, false)
+            .addLabeledComponent(JBLabel("Maximum PRs in list:"), prMaxTotalSpinner, 1, false)
             .addComponentFillVertically(JPanel(), 0)
 
         val formPanel = formBuilder.panel
@@ -147,23 +166,18 @@ class AzureDevOpsProjectConfigurable(private val project: Project) : Configurabl
         val accounts = accountManager.getAccounts()
 
         accountComboBox.removeAllItems()
-
-        // Add "None" option
         accountComboBox.addItem(AccountItem(null, "-- No Account (Use PAT from settings) --"))
 
-        // Add all accounts
+        // First pass: populate synchronously with neutral status icons so the combo box is
+        // immediately usable. getAccountAuthState() touches PasswordSafe (disk / OS keychain
+        // I/O) which is forbidden on the EDT, so the real icons are resolved off-EDT below.
         accounts.forEach { account ->
-            val state = accountManager.getAccountAuthState(account.id)
-            val statusIcon = when (state) {
-                AzureDevOpsAccountManager.AccountAuthState.VALID -> "✓"
-                AzureDevOpsAccountManager.AccountAuthState.EXPIRED -> "⚠"
-                AzureDevOpsAccountManager.AccountAuthState.REVOKED -> "✗"
-                else -> "?"
-            }
-            accountComboBox.addItem(AccountItem(account, "$statusIcon ${account.displayName}"))
+            accountComboBox.addItem(AccountItem(account, "… ${account.displayName}"))
         }
 
-        // Try to select current account (match by URL)
+        // Auto-select the account whose org matches the detected repo, mirroring the prior
+        // behavior. Runs against the placeholder items, which is fine — the rebuild below
+        // preserves the selection by account id.
         val detector = AzureDevOpsRepositoryDetector.getInstance(project)
         val detectedInfo = detector.detectAzureDevOpsInfo()
         if (detectedInfo != null) {
@@ -180,26 +194,68 @@ class AzureDevOpsProjectConfigurable(private val project: Project) : Configurabl
                 }
             }
         }
+
+        // Second pass: resolve real auth states off-EDT, then rebuild the combo while
+        // preserving the current selection.
+        if (accounts.isEmpty()) return
+        com.intellij.openapi.application.ApplicationManager.getApplication().executeOnPooledThread {
+            val resolved = accounts.map { account ->
+                val state = accountManager.getAccountAuthState(account.id)
+                val statusIcon = when (state) {
+                    AzureDevOpsAccountManager.AccountAuthState.VALID -> "✓"
+                    AzureDevOpsAccountManager.AccountAuthState.EXPIRED -> "⚠"
+                    AzureDevOpsAccountManager.AccountAuthState.REVOKED -> "✗"
+                    else -> "?"
+                }
+                account to "$statusIcon ${account.displayName}"
+            }
+            com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater {
+                val previousSelectionId = (accountComboBox.selectedItem as? AccountItem)?.account?.id
+                accountComboBox.removeAllItems()
+                accountComboBox.addItem(AccountItem(null, "-- No Account (Use PAT from settings) --"))
+                resolved.forEach { (acc, label) -> accountComboBox.addItem(AccountItem(acc, label)) }
+                if (previousSelectionId != null) {
+                    for (i in 0 until accountComboBox.itemCount) {
+                        if (accountComboBox.getItemAt(i).account?.id == previousSelectionId) {
+                            accountComboBox.selectedIndex = i
+                            break
+                        }
+                    }
+                }
+            }
+        }
     }
 
     private fun updateAccountStatus() {
         val selectedItem = accountComboBox.selectedItem as? AccountItem
-        if (selectedItem?.account != null) {
-            val accountManager = AzureDevOpsAccountManager.getInstance()
-            val state = accountManager.getAccountAuthState(selectedItem.account.id)
-
-            accountStatusLabel.text = when (state) {
-                AzureDevOpsAccountManager.AccountAuthState.VALID ->
-                    "<html><font color='green'>✓ Token is valid</font></html>"
-                AzureDevOpsAccountManager.AccountAuthState.EXPIRED ->
-                    "<html><font color='orange'>⚠ Token expired - use 'Manage Accounts' to refresh</font></html>"
-                AzureDevOpsAccountManager.AccountAuthState.REVOKED ->
-                    "<html><font color='red'>✗ Token revoked - use 'Manage Accounts' to re-authenticate</font></html>"
-                else ->
-                    "<html><font color='gray'>? Token status unknown</font></html>"
-            }
-        } else {
+        val account = selectedItem?.account
+        if (account == null) {
             accountStatusLabel.text = "<html><font color='gray'>Using project-level PAT (legacy mode)</font></html>"
+            return
+        }
+        // getAccountAuthState() reads the token from PasswordSafe, which does disk /
+        // OS-keychain I/O. Running it on the EDT triggers "Slow operations are prohibited"
+        // warnings, so we resolve the state on a pooled thread and update the label back
+        // on the EDT once we have the answer.
+        accountStatusLabel.text = "<html><font color='gray'>Checking token status…</font></html>"
+        val accountIdAtRequest = account.id
+        com.intellij.openapi.application.ApplicationManager.getApplication().executeOnPooledThread {
+            val state = AzureDevOpsAccountManager.getInstance().getAccountAuthState(accountIdAtRequest)
+            com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater {
+                // If the user changed the selection while we were resolving, drop this result.
+                val stillSelected = (accountComboBox.selectedItem as? AccountItem)?.account?.id == accountIdAtRequest
+                if (!stillSelected) return@invokeLater
+                accountStatusLabel.text = when (state) {
+                    AzureDevOpsAccountManager.AccountAuthState.VALID ->
+                        "<html><font color='green'>✓ Token is valid</font></html>"
+                    AzureDevOpsAccountManager.AccountAuthState.EXPIRED ->
+                        "<html><font color='orange'>⚠ Token expired - use 'Manage Accounts' to refresh</font></html>"
+                    AzureDevOpsAccountManager.AccountAuthState.REVOKED ->
+                        "<html><font color='red'>✗ Token revoked - use 'Manage Accounts' to re-authenticate</font></html>"
+                    else ->
+                        "<html><font color='gray'>? Token status unknown</font></html>"
+                }
+            }
         }
     }
 
@@ -217,43 +273,48 @@ class AzureDevOpsProjectConfigurable(private val project: Project) : Configurabl
         }
 
         val selectedItem = accountComboBox.selectedItem as? AccountItem
-        val token = if (selectedItem?.account != null) {
-            val accountManager = AzureDevOpsAccountManager.getInstance()
-            accountManager.getToken(selectedItem.account.id)
-        } else {
-            // Fallback to project-level PAT
-            AzureDevOpsConfigService.getInstance(project).getConfig().personalAccessToken
-        }
+        val accountForToken = selectedItem?.account
 
-        if (token.isNullOrBlank()) {
-            Messages.showErrorDialog(
-                project,
-                "No authentication token available.\nPlease select an account or configure a PAT.",
-                "No Token"
-            )
-            return
-        }
+        // Token fetch + HTTP probe must run off-EDT — PasswordSafe is a slow op, and the
+        // synchronous network call obviously can't block the UI thread either. Result is
+        // delivered back to the EDT for the success / failure dialog.
+        com.intellij.openapi.application.ApplicationManager.getApplication().executeOnPooledThread {
+            val token = if (accountForToken != null) {
+                AzureDevOpsAccountManager.getInstance().getToken(accountForToken.id)
+            } else {
+                AzureDevOpsConfigService.getInstance(project).getConfig().personalAccessToken
+            }
 
-        try {
-            val apiClient = AzureDevOpsApiClient.getInstance(project)
-            val url = apiClient.buildApiUrl(repoInfo.project, repoInfo.repository, "?api-version=7.0")
+            if (token.isNullOrBlank()) {
+                com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater {
+                    Messages.showErrorDialog(
+                        project,
+                        "No authentication token available.\nPlease select an account or configure a PAT.",
+                        "No Token"
+                    )
+                }
+                return@executeOnPooledThread
+            }
 
-            testConnectionDirectly(url, token)
+            val outcome: Pair<Boolean, String> = try {
+                val apiClient = AzureDevOpsApiClient.getInstance(project)
+                val url = apiClient.buildApiUrl(repoInfo.project, repoInfo.repository, "?api-version=7.0")
+                testConnectionDirectly(url, token)
+                true to "Successfully connected to Azure DevOps!\n\n" +
+                    "Organization: ${repoInfo.organization}\n" +
+                    "Project: ${repoInfo.project}\n" +
+                    "Repository: ${repoInfo.repository}"
+            } catch (e: Exception) {
+                false to (e.message ?: "Unknown error")
+            }
 
-            Messages.showInfoMessage(
-                project,
-                "Successfully connected to Azure DevOps!\n\n" +
-                        "Organization: ${repoInfo.organization}\n" +
-                        "Project: ${repoInfo.project}\n" +
-                        "Repository: ${repoInfo.repository}",
-                "Connection Test Successful"
-            )
-        } catch (e: Exception) {
-            Messages.showErrorDialog(
-                project,
-                "Connection test failed:\n\n${e.message}",
-                "Connection Error"
-            )
+            com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater {
+                if (outcome.first) {
+                    Messages.showInfoMessage(project, outcome.second, "Connection Test Successful")
+                } else {
+                    Messages.showErrorDialog(project, "Connection test failed:\n\n${outcome.second}", "Connection Error")
+                }
+            }
         }
     }
 
@@ -292,7 +353,9 @@ class AzureDevOpsProjectConfigurable(private val project: Project) : Configurabl
         return prIntervalSpinner.value as Long != settings.pullRequestIntervalSeconds ||
                 commentsIntervalSpinner.value as Long != settings.commentsIntervalSeconds ||
                 timelineIntervalSpinner.value as Long != settings.timelineIntervalSeconds ||
-                statusBarIntervalSpinner.value as Long != settings.statusBarIntervalSeconds
+                statusBarIntervalSpinner.value as Long != settings.statusBarIntervalSeconds ||
+                prPageSizeSpinner.value as Int != settings.pullRequestPageSize ||
+                prMaxTotalSpinner.value as Int != settings.pullRequestMaxTotal
     }
 
     override fun apply() {
@@ -302,6 +365,8 @@ class AzureDevOpsProjectConfigurable(private val project: Project) : Configurabl
         state.commentsIntervalSeconds = commentsIntervalSpinner.value as Long
         state.timelineIntervalSeconds = timelineIntervalSpinner.value as Long
         state.statusBarIntervalSeconds = statusBarIntervalSpinner.value as Long
+        state.pullRequestPageSize = prPageSizeSpinner.value as Int
+        state.pullRequestMaxTotal = prMaxTotalSpinner.value as Int
 
         // Reschedule active polling services with new intervals
         PullRequestsPollingService.getInstance(project).reschedule()
@@ -318,6 +383,8 @@ class AzureDevOpsProjectConfigurable(private val project: Project) : Configurabl
         commentsIntervalSpinner.value = settings.commentsIntervalSeconds
         timelineIntervalSpinner.value = settings.timelineIntervalSeconds
         statusBarIntervalSpinner.value = settings.statusBarIntervalSeconds
+        prPageSizeSpinner.value = settings.pullRequestPageSize
+        prMaxTotalSpinner.value = settings.pullRequestMaxTotal
     }
 
     override fun disposeUIResources() {

--- a/src/main/kotlin/paol0b/azuredevops/ui/CreatePullRequestDialog.kt
+++ b/src/main/kotlin/paol0b/azuredevops/ui/CreatePullRequestDialog.kt
@@ -184,9 +184,9 @@ class CreatePullRequestDialog private constructor(
         targetBranchCombo.renderer = BranchListCellRenderer()
 
         // Enable type-to-filter inside the dropdown popup, matching by branch displayName
-        val branchTextExtractor: (Any?) -> String? = { (it as? GitBranch)?.displayName }
-        ComboboxSpeedSearch(sourceBranchCombo, branchTextExtractor)
-        ComboboxSpeedSearch(targetBranchCombo, branchTextExtractor)
+        val branchTextExtractor: (GitBranch) -> String = { it.displayName }
+        ComboboxSpeedSearch.installSpeedSearch(sourceBranchCombo, branchTextExtractor)
+        ComboboxSpeedSearch.installSpeedSearch(targetBranchCombo, branchTextExtractor)
 
         // Description area setup
         descriptionArea.lineWrap = true

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -3,7 +3,7 @@
     <idea-version since-build="253" />
     <!-- Unique identifier of the plugin. It should be FQN. It cannot be changed between the plugin versions. -->
     <id>paol0b.AzureDevOps</id>
-    <version>4.0</version>
+    <version>4.1</version>
 
     <!-- Public plugin name should be written in Title Case.
          Guidelines: https://plugins.jetbrains.com/docs/marketplace/best-practices-for-listing.html#plugin-name -->


### PR DESCRIPTION
I was using the plugin with a relatively large organization and noticed that the view to clone a project from azure devops was really slow to load. I was also encountering some issue with the PR list view as it only does one call to the api endpoint to load the PRs but that endpoint is paginated when querying larger amount of data. Furthermore the Project filter's values were loaded from the queried data and not the API making it impossible to see PRs from a project that was not already loaded

The goal of this PR is to improve this view to make it more usable for larger scales. To achieve that is did the following:

- **Added loading parallelism**: when reaching the page we now load 8 projects at a time (value set to avoid doing too many concurrent tasks) and yield their results to the tree view as soon as returned. This allow for a quick time to first data and makes the load feel fast.
- **Add Project Filtering**: To further improve the experience, i added a project filter. it loads the list of the project and by default selects them all. The user can then select one or more project and they will appear as cards in the field. those cards have a button to allow easy removal of the selected projects. To select more projects you can click the field and a dropdown will appear listing all the projects with a search field and two buttons, one to deselect all and the other to select all. When no projects are selected, it default back to 'all selected' in order to not show nothing.
- **Imporve PRs Querying**: Now instead of only loading the first page of PRs, it load dynamically N PRs up to X amount of PRs where N and X are can be configured in the project settings. Their default values are N = 200 and X = 2000 (looks high but did not see any performance issues with it)
- **Improves PRs filtering**: The Project filter in the PR list view now loads all the projects from your organization allowing you to search for projects that might not have any already queried PRs. Modified the loading / refresh logic to not reload all the projects but simply the selected one if a filter is set. This will help fix Issue #60 and #61
